### PR TITLE
Exposed header date did change delegate method via day view delegate

### DIFF
--- a/CalendarKitDemo/Podfile.lock
+++ b/CalendarKitDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CalendarKit (0.1.6):
+  - CalendarKit (0.1.7):
     - DateToolsSwift
     - DynamicColor
     - Neon
@@ -12,10 +12,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   CalendarKit:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
-  CalendarKit: f3b08566e4ee01f4a7db7616ad440b6d4db808c2
+  CalendarKit: a29de9439d98d66b5ef2c582da7c7529ef36254c
   DateToolsSwift: 27336736d877c8734159da1f37afbda2aa704649
   DynamicColor: 4786d650c69da6c3f2cbfe068348288ec4e5521f
   Neon: 7fb5a9327e7e57911843f608e08f4893a74deaf9

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -9,6 +9,7 @@ public protocol DayViewDataSource: class {
 public protocol DayViewDelegate: class {
   func dayViewDidSelectEventView(_ eventview: EventView)
   func dayViewDidLongPressEventView(_ eventView: EventView)
+  func dayViewDidSelectDate(_ date: Date)
 }
 
 public class DayView: UIView {
@@ -135,6 +136,7 @@ extension DayView: PagingScrollViewDelegate {
 
 extension DayView: DayHeaderViewDelegate {
   public func dateHeaderDateChanged(_ newDate: Date) {
+    delegate?.dayViewDidSelectDate(newDate)
     if newDate.isEarlier(than: currentDate) {
       let timelineContainer = timelinePager.reusableViews.first!
       timelineContainer.timeline.date = newDate

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -9,7 +9,8 @@ public protocol DayViewDataSource: class {
 public protocol DayViewDelegate: class {
   func dayViewDidSelectEventView(_ eventview: EventView)
   func dayViewDidLongPressEventView(_ eventView: EventView)
-  func dayViewDidSelectDate(_ date: Date)
+  func dayView(dayView: DayView, willMoveTo date: Date)
+  func dayView(dayView: DayView, didMoveTo  date: Date)
 }
 
 public class DayView: UIView {
@@ -130,13 +131,14 @@ extension DayView: PagingScrollViewDelegate {
   func scrollviewDidScrollToViewAtIndex(_ index: Int) {
     let timeline = timelinePager.reusableViews[index].timeline
     currentDate = timeline!.date
+    delegate?.dayView(dayView: self, willMoveTo: currentDate)
     dayHeaderView.selectDate(currentDate)
+    delegate?.dayView(dayView: self, didMoveTo: currentDate)
   }
 }
 
 extension DayView: DayHeaderViewDelegate {
   public func dateHeaderDateChanged(_ newDate: Date) {
-    delegate?.dayViewDidSelectDate(newDate)
     if newDate.isEarlier(than: currentDate) {
       let timelineContainer = timelinePager.reusableViews.first!
       timelineContainer.timeline.date = newDate

--- a/Source/DayViewController.swift
+++ b/Source/DayViewController.swift
@@ -43,4 +43,12 @@ extension DayViewController: DayViewDataSource {
   open func dayViewDidLongPressEventView(_ eventView: EventView) {
     
   }
+
+  public func dayView(dayView: DayView, willMoveTo date: Date) {
+    print("DayView = \(dayView) will move to: \(date)")
+  }
+
+  public func dayView(dayView: DayView, didMoveTo date: Date) {
+    print("DayView = \(dayView) did move to: \(date)")
+  }
 }

--- a/Source/Timeline/EventView.swift
+++ b/Source/Timeline/EventView.swift
@@ -29,6 +29,8 @@ open class EventView: UIView {
     }
   }
 
+  public var extraData: Any?
+
   lazy var textView: UITextView = {
     let view = UITextView()
     view.font = UIFont.boldSystemFont(ofSize: 12)

--- a/Source/Timeline/EventView.swift
+++ b/Source/Timeline/EventView.swift
@@ -29,7 +29,7 @@ open class EventView: UIView {
     }
   }
 
-  public var extraData: Any?
+  public var userInfo: Any?
 
   lazy var textView: UITextView = {
     let view = UITextView()


### PR DESCRIPTION
Great framework!

Really saved my butt the other day where I had to implement a calendar in a day.

Realized I needed to know when a user clicks on a date, to do some logic. 

I figure this could be done in the Event Views for Date method. But I think it would be the wrong architecture, since that method is a data source and shouldn't be used as a delegate. Besides, if in the future the Events are gathered before a user actually clicks, for some sort of pre-fetching, then this would break that anyways.