### PR TITLE
Allow BYO header view, ability to set current date, maintain date order after a jump, long press timeline delegate callback

### DIFF
--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -63,6 +63,22 @@ public class DayView: UIView {
     }
   }
 
+  public func changeCurrentDate(to newDate: Date) {
+    var newDate = newDate.dateOnly()
+    if newDate.isEarlier(than: currentDate) {
+      let timelineContainer = timelinePager.reusableViews.first!
+      timelineContainer.timeline.date = newDate
+      updateTimeline(timelineContainer.timeline)
+      timelinePager.scrollBackward()
+    } else if newDate.isLater(than: currentDate) {
+      let timelineContainer = timelinePager.reusableViews.last!
+      timelineContainer.timeline.date = newDate
+      updateTimeline(timelineContainer.timeline)
+      timelinePager.scrollForward()
+    }
+    currentDate = newDate
+  }
+
   func configureTimelinePager() {
     var verticalScrollViews = [TimelineContainer]()
     for i in -1...1 {
@@ -149,16 +165,6 @@ extension DayView: PagingScrollViewDelegate {
 
 extension DayView: DayHeaderViewDelegate {
   public func dateHeaderDateChanged(_ newDate: Date) {
-    if newDate.isEarlier(than: currentDate) {
-      let timelineContainer = timelinePager.reusableViews.first!
-      timelineContainer.timeline.date = newDate
-      updateTimeline(timelineContainer.timeline)
-      timelinePager.scrollBackward()
-    } else if newDate.isLater(than: currentDate) {
-      let timelineContainer = timelinePager.reusableViews.last!
-      timelineContainer.timeline.date = newDate
-      updateTimeline(timelineContainer.timeline)
-      timelinePager.scrollForward()
-    }
+    changeCurrentDate(to: newDate)
   }
 }

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -15,10 +15,20 @@ public protocol DayViewDelegate: class {
 
 public class DayView: UIView {
 
+  /// Hides or shows header view
+  public var isHeaderViewVisible = true {
+    didSet {
+      headerHeight = isHeaderViewVisible ? DayView.headerVisibleHeight : 0
+      dayHeaderView.isHidden = !isHeaderViewVisible
+      setNeedsLayout()
+    }
+  }
+  
   public weak var dataSource: DayViewDataSource?
   public weak var delegate: DayViewDelegate?
 
-  var headerHeight: CGFloat = 88
+  static let headerVisibleHeight: CGFloat = 88
+  var headerHeight: CGFloat = headerVisibleHeight
 
   let dayHeaderView = DayHeaderView()
   let timelinePager = PagingScrollView<TimelineContainer>()

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -66,14 +66,24 @@ public class DayView: UIView {
   public func changeCurrentDate(to newDate: Date) {
     var newDate = newDate.dateOnly()
     if newDate.isEarlier(than: currentDate) {
-      let timelineContainer = timelinePager.reusableViews.first!
-      timelineContainer.timeline.date = newDate
-      updateTimeline(timelineContainer.timeline)
+      var timelineDate = newDate
+      for (index, timelineContainer) in timelinePager.reusableViews.enumerated() {
+        timelineContainer.timeline.date = timelineDate
+        timelineDate = timelineDate.add(TimeChunk(seconds: 0, minutes: 0, hours: 0, days: 1, weeks: 0, months: 0, years: 0))
+        if index == 0 {
+          updateTimeline(timelineContainer.timeline)
+        }
+      }
       timelinePager.scrollBackward()
     } else if newDate.isLater(than: currentDate) {
-      let timelineContainer = timelinePager.reusableViews.last!
-      timelineContainer.timeline.date = newDate
-      updateTimeline(timelineContainer.timeline)
+      var timelineDate = newDate
+      for (index, timelineContainer) in timelinePager.reusableViews.reversed().enumerated() {
+        timelineContainer.timeline.date = timelineDate
+        timelineDate = timelineDate.subtract(TimeChunk(seconds: 0, minutes: 0, hours: 0, days: 1, weeks: 0, months: 0, years: 0))
+        if index == 0 {
+          updateTimeline(timelineContainer.timeline)
+        }
+      }
       timelinePager.scrollForward()
     }
     currentDate = newDate

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -9,6 +9,7 @@ public protocol DayViewDataSource: class {
 public protocol DayViewDelegate: class {
   func dayViewDidSelectEventView(_ eventview: EventView)
   func dayViewDidLongPressEventView(_ eventView: EventView)
+  func dayViewDidLongPressTimelineAtHour(_ hour: Int)
   func dayView(dayView: DayView, willMoveTo date: Date)
   func dayView(dayView: DayView, didMoveTo  date: Date)
 }
@@ -94,6 +95,7 @@ public class DayView: UIView {
     var verticalScrollViews = [TimelineContainer]()
     for i in -1...1 {
       let timeline = TimelineView(frame: bounds)
+      timeline.delegate = self
       timeline.frame.size.height = timeline.fullHeight
       timeline.date = currentDate.add(TimeChunk(seconds: 0,
                                                 minutes: 0,
@@ -177,5 +179,11 @@ extension DayView: PagingScrollViewDelegate {
 extension DayView: DayHeaderViewDelegate {
   public func dateHeaderDateChanged(_ newDate: Date) {
     changeCurrentDate(to: newDate)
+  }
+}
+
+extension DayView: TimelineViewDelegate {
+  func timelineView(_ timelineView: TimelineView, didLongPressAt hour: Int) {
+    delegate?.dayViewDidLongPressTimelineAtHour(hour)
   }
 }

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -20,6 +20,7 @@ public class DayView: UIView {
     didSet {
       headerHeight = isHeaderViewVisible ? DayView.headerVisibleHeight : 0
       dayHeaderView.isHidden = !isHeaderViewVisible
+      dayHeaderView.delegate = isHeaderViewVisible ? self : nil
       setNeedsLayout()
     }
   }

--- a/Source/DayViewController.swift
+++ b/Source/DayViewController.swift
@@ -44,6 +44,10 @@ extension DayViewController: DayViewDataSource {
     
   }
 
+  public func dayViewDidLongPressTimelineAtHour(_ hour: Int) {
+
+  }
+
   public func dayView(dayView: DayView, willMoveTo date: Date) {
     print("DayView = \(dayView) will move to: \(date)")
   }

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -2,7 +2,14 @@ import UIKit
 import Neon
 import DateToolsSwift
 
+
+protocol TimelineViewDelegate: class {
+  func timelineView(_ timelineView: TimelineView, didLongPressAt hour: Int)
+}
+
 public class TimelineView: UIView, ReusableView {
+
+  weak var delegate: TimelineViewDelegate?
 
   var date = Date() {
     didSet {
@@ -66,6 +73,8 @@ public class TimelineView: UIView, ReusableView {
 
   fileprivate lazy var _12hTimes: [String] = Generator.timeStrings12H()
   fileprivate lazy var _24hTimes: [String] = Generator.timeStrings24H()
+  
+  fileprivate lazy var longPressGestureRecognizer: UILongPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(longPress(_:)))
 
   var isToday: Bool {
     return date.isToday
@@ -87,6 +96,19 @@ public class TimelineView: UIView, ReusableView {
     contentMode = .redraw
     backgroundColor = .white
     addSubview(nowLine)
+    
+    // Add long press gesture recognizer
+    addGestureRecognizer(longPressGestureRecognizer)
+  }
+  
+  func longPress(_ gestureRecognizer: UILongPressGestureRecognizer) {
+    if (gestureRecognizer.state == .began) {
+      // Get timeslot of gesture location
+      let pressedLocation = gestureRecognizer.location(in: self)
+      let percentOfHeight = (pressedLocation.y - verticalInset) / (bounds.height - (verticalInset * 2))
+      let pressedAtHour: Int = Int(24 * percentOfHeight)
+      delegate?.timelineView(self, didLongPressAt: pressedAtHour)
+    }
   }
 
   public func updateStyle(_ newStyle: TimelineStyle) {


### PR DESCRIPTION
1. BYO header view
 - Allow hiding the built-in header view so that users can use their own header views

2. Ability to set current date
 - Expose function to set the current date in `DayView`

3. Maintain date order after a jump
 - When jumping dates (by tapping on date in header view instead of swiping), the next swipe back jumps back to the previous date before the jump, instead of the previous date in the calendar. This fixes that issue.

4. Long press in timeline view delegate callback
 - Add delegate callback when the timeline view is long pressed in an area without any events