### PR TITLE
Expose day view scroll offset, expose ability to set timeline pan gesture's `require(toFail:)` method

### DIFF
--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -25,6 +25,10 @@ public class DayView: UIView {
       setNeedsLayout()
     }
   }
+  public var currentTimelineScrollOffset: CGPoint {
+    // Any view is fine as they are all synchronized
+    return timelinePager.reusableViews.first?.contentOffset ?? CGPoint()
+  }
   
   public weak var dataSource: DayViewDataSource?
   public weak var delegate: DayViewDelegate?

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -94,6 +94,12 @@ public class DayView: UIView {
     }
     currentDate = newDate
   }
+  
+  public func timelinePanGestureRequire(toFail gesture: UIGestureRecognizer) {
+    for timelineContainer in timelinePager.reusableViews {
+      timelineContainer.panGestureRecognizer.require(toFail: gesture)
+    }
+  }
 
   func configureTimelinePager() {
     var verticalScrollViews = [TimelineContainer]()

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -25,7 +25,7 @@ public class DayView: UIView {
       setNeedsLayout()
     }
   }
-  public var currentTimelineScrollOffset: CGPoint {
+  public var timelineScrollOffset: CGPoint {
     // Any view is fine as they are all synchronized
     return timelinePager.reusableViews.first?.contentOffset ?? CGPoint()
   }


### PR DESCRIPTION
1. Expose day view scroll offset:
 - Thought it might be useful to get the current scroll offset of the day view. In my case, I use it to determine if it's at the top and if it is, allow other gestures to work, i.e. expanding week/month header view.

2. Ability to set timeline's pan gesture's `require(toFail:)` method
 - Thought it might be useful to allow only certain gestures to work together. I.e. if another pan gesture has been detected, do not allow timeline to scroll. In my case, I use it expand/shrink the week/month header view and not scroll the day view at the same time.