### PR TITLE
Allow injection of custom header

### DIFF
--- a/Source/CalendarStyle.swift
+++ b/Source/CalendarStyle.swift
@@ -10,6 +10,10 @@ public class CalendarStyle: NSCopying {
   }
 }
 
+public protocol DayHeaderStyleProtocol {
+  func updateStyle(_ newStyle: DayHeaderStyle)
+}
+
 public class DayHeaderStyle: NSCopying {
   public var daySymbols = DaySymbolsStyle()
   public var daySelector = DaySelectorStyle()

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -19,6 +19,12 @@ public protocol DayHeaderProtocol {
   func selectDate(_ selectedDate: Date)
 }
 
+  /// Component used only as initialization parameter to enforce both view & controller
+public struct DayHeaderComponent {
+  let view: UIView
+  let controller: DayHeaderProtocol & DayHeaderStyleProtocol
+}
+
 public class DayView: UIView {
 
   /// Hides or shows header view
@@ -26,7 +32,7 @@ public class DayView: UIView {
     didSet {
       headerHeight = isHeaderViewVisible ? DayView.headerVisibleHeight : 0
       dayHeaderView.isHidden = !isHeaderViewVisible
-      dayHeaderView.delegate = isHeaderViewVisible ? self : nil
+      dayHeaderController.delegate = isHeaderViewVisible ? self : nil
       setNeedsLayout()
     }
   }
@@ -41,7 +47,9 @@ public class DayView: UIView {
   static let headerVisibleHeight: CGFloat = 88
   var headerHeight: CGFloat = headerVisibleHeight
 
-  let dayHeaderView = DayHeaderView()
+  var dayHeaderView: UIView
+  var dayHeaderController: DayHeaderProtocol & DayHeaderStyleProtocol
+
   let timelinePager = PagingScrollView<TimelineContainer>()
   var timelineSynchronizer: ScrollSynchronizer?
 
@@ -61,13 +69,13 @@ public class DayView: UIView {
 
   func configure() {
     configureTimelinePager()
-    dayHeaderView.delegate = self
+    dayHeaderController.delegate = self
     addSubview(dayHeaderView)
   }
 
   public func updateStyle(_ newStyle: CalendarStyle) {
     style = newStyle.copy() as! CalendarStyle
-    dayHeaderView.updateStyle(style.header)
+    dayHeaderController.updateStyle(style.header)
     timelinePager.reusableViews.forEach{ timelineContainer in
       timelineContainer.timeline.updateStyle(style.timeline)
       timelineContainer.backgroundColor = style.timeline.backgroundColor
@@ -186,7 +194,7 @@ extension DayView: PagingScrollViewDelegate {
     let nextDate = timelinePager.reusableViews[index].timeline.date
     delegate?.dayView(dayView: self, willMoveTo: nextDate)
     currentDate = nextDate
-    dayHeaderView.selectDate(currentDate)
+    dayHeaderController.selectDate(currentDate)
     delegate?.dayView(dayView: self, didMoveTo: currentDate)
   }
 }

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -14,6 +14,11 @@ public protocol DayViewDelegate: class {
   func dayView(dayView: DayView, didMoveTo  date: Date)
 }
 
+public protocol DayHeaderProtocol {
+  var delegate: DayHeaderViewDelegate? {get set}
+  func selectDate(_ selectedDate: Date)
+}
+
 public class DayView: UIView {
 
   /// Hides or shows header view

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -57,12 +57,23 @@ public class DayView: UIView {
 
   var style = CalendarStyle()
 
-  override public init(frame: CGRect) {
-    super.init(frame: frame)
+  public init(headerComponent: DayHeaderComponent? = nil) {
+    if let headerComponent = headerComponent {
+      dayHeaderView = headerComponent.view
+      dayHeaderController = headerComponent.controller
+    } else {
+      let defaultHeader = DayHeaderView()
+      dayHeaderView = defaultHeader
+      dayHeaderController = defaultHeader
+    }
+    super.init(frame: .zero)
     configure()
   }
 
   required public init?(coder aDecoder: NSCoder) {
+    let defaultHeader = DayHeaderView()
+    dayHeaderView = defaultHeader
+    dayHeaderController = defaultHeader
     super.init(coder: aDecoder)
     configure()
   }

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -49,7 +49,7 @@ public class DayView: UIView {
   public weak var delegate: DayViewDelegate?
 
   static let headerVisibleHeight: CGFloat = 88
-  var headerHeight: CGFloat = headerVisibleHeight
+  public var headerHeight: CGFloat = headerVisibleHeight
 
   var dayHeaderView: UIView
   var dayHeaderController: DayHeaderProtocol & DayHeaderStyleProtocol

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -19,10 +19,14 @@ public protocol DayHeaderProtocol {
   func selectDate(_ selectedDate: Date)
 }
 
-  /// Component used only as initialization parameter to enforce both view & controller
+/// Component used only as initialization parameter to enforce both view & controller
 public struct DayHeaderComponent {
-  let view: UIView
-  let controller: DayHeaderProtocol & DayHeaderStyleProtocol
+  public let view: UIView
+  public let controller: DayHeaderProtocol & DayHeaderStyleProtocol
+  public init(view: UIView, controller: DayHeaderProtocol & DayHeaderStyleProtocol) {
+    self.view = view
+    self.controller = controller
+  }
 }
 
 public class DayView: UIView {

--- a/Source/Header/DayHeaderView.swift
+++ b/Source/Header/DayHeaderView.swift
@@ -5,7 +5,7 @@ public protocol DayHeaderViewDelegate: class {
   func dateHeaderDateChanged(_ newDate: Date)
 }
 
-public class DayHeaderView: UIView {
+public class DayHeaderView: UIView, DayHeaderProtocol, DayHeaderStyleProtocol {
 
   public weak var delegate: DayHeaderViewDelegate?
 


### PR DESCRIPTION
As discussed in #33,

1. I've split responsibility between two entities (which may be represented by instance of one class): `dayHeaderController` and `dayHeaderView`

The `controller` is responsible for implementing appropriate protocols for changing date, style and assigning a delegate, while `view` could be just a subclass of an `UIView`. 

These objects could be independent entities (i.e. let's say `HeaderViewController` and `HeaderViewController.view`, but also that responsibility could be in one class, like currently in `DayHeaderView`

2. To enforce that either both of the entities are nil, or both present during initialization, I've created a struct which could be initialized only with two of them.

@v-ken, please, take  a look at this approach and if it looks good, try to test with your project. Once everything is OK, we're ready to merge.