### PR TITLE
Ability to scroll to a specific time, fix events starting or ending on a different date

### DIFF
--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -103,6 +103,11 @@ public class DayView: UIView {
       timelineContainer.panGestureRecognizer.require(toFail: gesture)
     }
   }
+  
+  public func scrollTo(hour24: Float) {
+    // Any view is fine as they are all synchronized
+    timelinePager.reusableViews.first?.scrollTo(hour24: hour24)
+  }
 
   func configureTimelinePager() {
     var verticalScrollViews = [TimelineContainer]()

--- a/Source/Timeline/TimelineContainer.swift
+++ b/Source/Timeline/TimelineContainer.swift
@@ -16,4 +16,11 @@ class TimelineContainer: UIScrollView, ReusableView {
     let yToScroll = timeline.firstEventYPosition ?? 0
     setContentOffset(CGPoint(x: contentOffset.x, y: yToScroll), animated: true)
   }
+  
+  func scrollTo(hour24: Float) {
+    let percentToScroll = CGFloat(hour24 / 24)
+    let yToScroll = contentSize.height * percentToScroll
+    let padding: CGFloat = 8
+    setContentOffset(CGPoint(x: contentOffset.x, y: yToScroll - padding), animated: true)
+  }
 }

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -276,8 +276,16 @@ public class TimelineView: UIView, ReusableView {
   }
 
   fileprivate func dateToY(_ date: Date) -> CGFloat {
-    let hourY = CGFloat(date.hour) * verticalDiff + verticalInset
-    let minuteY = CGFloat(date.minute) * verticalDiff / 60
-    return hourY + minuteY
+    if date.dateOnly() > self.date.dateOnly() {
+      // Event ending the next day
+      return 24 * verticalDiff + verticalInset
+    } else if date.dateOnly() < self.date.dateOnly() {
+      // Event starting the previous day
+      return verticalInset
+    } else {
+      let hourY = CGFloat(date.hour) * verticalDiff + verticalInset
+      let minuteY = CGFloat(date.minute) * verticalDiff / 60
+      return hourY + minuteY
+    }
   }
 }


### PR DESCRIPTION
1. Ability to scroll to a specific time.
 - E.g. Loading the calendar from 8am
2. Fix events starting or ending on a different date
 - Previously only the hour and minute of a date are used for calculation.