### PR TITLE
When preparing event views, start by releasing all existing event views

### DIFF
--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -253,6 +253,8 @@ public class TimelineView: UIView, ReusableView {
   }
 
   func prepareEventViews() {
+    pool.enqueue(views: eventViews)
+    eventViews.removeAll()
     for _ in 0...eventDescriptors.endIndex {
       let newView = pool.dequeue()
       newView.delegate = eventViewDelegate


### PR DESCRIPTION
…ws so that ones for which an event descriptor no longer exists do not hang around.