### PR TITLE
Fix autoscroll not working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ before_install:
 
 script:
 - xcodebuild build -workspace CalendarKitDemo.xcworkspace -scheme "CalendarKitDemo" -sdk iphonesimulator | xcpretty
+
+notifications:
+  email: false

--- a/CalendarKitDemo/CalendarKitDemo/ExampleController.swift
+++ b/CalendarKitDemo/CalendarKitDemo/ExampleController.swift
@@ -59,6 +59,7 @@ class ExampleController: DayViewController {
                                                         target: self,
                                                         action: #selector(ExampleController.changeStyle))
     navigationController?.navigationBar.isTranslucent = false
+    dayView.autoScrollToFirstEvent = true
     reloadData()
   }
 

--- a/Source/DayView.swift
+++ b/Source/DayView.swift
@@ -92,6 +92,10 @@ public class DayView: UIView {
     timelinePagerView.scrollTo(hour24: hour24)
   }
 
+  public func scrollToFirstEventIfNeeded() {
+    timelinePagerView.scrollToFirstEventIfNeeded()
+  }
+
   func configureTimelinePager() {
     addSubview(timelinePagerView)
     timelinePagerView.delegate = self

--- a/Source/DayViewController.swift
+++ b/Source/DayViewController.swift
@@ -16,6 +16,11 @@ open class DayViewController: UIViewController, EventDataSource, DayViewDelegate
     dayView.reloadData()
   }
 
+  open override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    dayView.scrollToFirstEventIfNeeded()
+  }
+
   open override func viewDidLayoutSubviews() {
     dayView.fillSuperview()
   }

--- a/Source/PagingScrollView.swift
+++ b/Source/PagingScrollView.swift
@@ -19,7 +19,10 @@ class PagingScrollView<T: UIView>: UIScrollView, UIScrollViewDelegate where T: R
     get {
       let width = bounds.width
       let centerOffsetX = contentOffset.x + width / 2
-      return centerOffsetX / width - 0.5
+
+      let result = centerOffsetX / width - 0.5
+      // Return central page if impossible to calculate (View has no size yet)
+      return result.isNaN ? 1 : result
     }
   }
 

--- a/Source/Timeline/TimelineContainer.swift
+++ b/Source/Timeline/TimelineContainer.swift
@@ -14,7 +14,7 @@ class TimelineContainer: UIScrollView, ReusableView {
 
   func scrollToFirstEvent() {
     if let yToScroll = timeline.firstEventYPosition {
-      setContentOffset(CGPoint(x: contentOffset.x, y: yToScroll), animated: true)
+      setContentOffset(CGPoint(x: contentOffset.x, y: yToScroll - 15), animated: true)
     }
   }
   

--- a/Source/Timeline/TimelineContainer.swift
+++ b/Source/Timeline/TimelineContainer.swift
@@ -13,8 +13,9 @@ class TimelineContainer: UIScrollView, ReusableView {
   }
 
   func scrollToFirstEvent() {
-    let yToScroll = timeline.firstEventYPosition ?? 0
-    setContentOffset(CGPoint(x: contentOffset.x, y: yToScroll), animated: true)
+    if let yToScroll = timeline.firstEventYPosition {
+      setContentOffset(CGPoint(x: contentOffset.x, y: yToScroll), animated: true)
+    }
   }
   
   func scrollTo(hour24: Float) {

--- a/Source/Timeline/TimelinePagerView.swift
+++ b/Source/Timeline/TimelinePagerView.swift
@@ -128,8 +128,12 @@ public class TimelinePagerView: UIView {
 
   func updateTimeline(_ timeline: TimelineView) {
     guard let dataSource = dataSource else {return}
-    let events = dataSource.eventsForDate(timeline.date)
-    timeline.eventDescriptors = events
+    let date = timeline.date.dateOnly()
+    let events = dataSource.eventsForDate(date)
+    let day = TimePeriod(beginning: date,
+                         chunk: TimeChunk.dateComponents(days: 1))
+    let validEvents = events.filter{$0.datePeriod.overlaps(with: day)}
+    timeline.eventDescriptors = validEvents
   }
 }
 

--- a/Source/Timeline/TimelinePagerView.swift
+++ b/Source/Timeline/TimelinePagerView.swift
@@ -149,15 +149,15 @@ extension TimelinePagerView: PagingScrollViewDelegate {
     let nextDate = timelinePager.reusableViews[index].timeline.date
     delegate?.timelinePager(timelinePager: self, willMoveTo: nextDate)
     currentDate = nextDate
-    if autoScrollToFirstEvent {
-      scrollToFirstEvent()
-    }
+    scrollToFirstEventIfNeeded()
     delegate?.timelinePager(timelinePager: self, didMoveTo: nextDate)
   }
 
-  func scrollToFirstEvent() {
-    let index = Int(timelinePager.currentScrollViewPage)
-    timelinePager.reusableViews[index].scrollToFirstEvent()
+  func scrollToFirstEventIfNeeded() {
+    if autoScrollToFirstEvent {
+      let index = Int(timelinePager.currentScrollViewPage)
+      timelinePager.reusableViews[index].scrollToFirstEvent()
+    }
   }
 }
 

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -206,16 +206,12 @@ public class TimelineView: UIView, ReusableView {
   }
 
   func recalculateEventLayout() {
-    let day = TimePeriod(beginning: date.dateOnly(),
-                         chunk: TimeChunk.dateComponents(days: 1))
-
-    let validEvents = eventDescriptors.filter {$0.datePeriod.overlaps(with: day)}
-      .sorted {$0.datePeriod.beginning!.isEarlier(than: $1.datePeriod.beginning!)}
+    let sortedEvents = eventDescriptors.sorted {$0.datePeriod.beginning!.isEarlier(than: $1.datePeriod.beginning!)}
 
     var groupsOfEvents = [[EventDescriptor]]()
     var overlappingEvents = [EventDescriptor]()
 
-    for event in validEvents {
+    for event in sortedEvents {
       if overlappingEvents.isEmpty {
         overlappingEvents.append(event)
         continue

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -34,7 +34,7 @@ public class TimelineView: UIView, ReusableView {
   var pool = ReusePool<EventView>()
 
   var firstEventYPosition: CGFloat? {
-    return eventViews.sorted{$0.frame.origin.y < $1.frame.origin.y}
+    return eventDescriptors.sorted{$0.frame.origin.y < $1.frame.origin.y}
       .first?.frame.origin.y
   }
 


### PR DESCRIPTION
Fix for issue #50, when `autoScrollToFirstEvent` function was either not working or worked incorrectly.

The problem was related to invalid events being present in Timeline with default `CGRect` set to zero. When asked for the topmost event, the `Timeline` returned the one with zero `CGRect`, as it was "topmost", even if that event has been discarded as invalid and was not used during layout calculation.

Now incorrect events are removed just after receiving them from the `dataSource` and do not propagate further into system.