### PR TITLE
Fix issue #61

### DIFF
--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -216,7 +216,11 @@ public class TimelineView: UIView, ReusableView {
         overlappingEvents.append(event)
         continue
       }
-      if overlappingEvents.last!.datePeriod.overlaps(with: event.datePeriod) {
+
+      let longestEvent = overlappingEvents.sorted{$0.datePeriod.seconds > $1.datePeriod.seconds}.first!
+      let lastEvent = overlappingEvents.last!
+      if longestEvent.datePeriod.overlaps(with: event.datePeriod) ||
+        lastEvent.datePeriod.overlaps(with: event.datePeriod) {
         overlappingEvents.append(event)
         continue
       } else {


### PR DESCRIPTION
Fix issue #61

I've added check not only for overlapping with last event, but with longest in the group. This algorithm is not perfect and may produce more columns than needed, for example, here it is possible to use only two columns.
![simulator screen shot jun 24 2017 15 48 05](https://user-images.githubusercontent.com/8013017/27508908-e5e4e1e6-58f8-11e7-8b3b-3218e4a54bca.png)

However, iOS calendar algorithm is different and it allows overlapping:
![image](https://user-images.githubusercontent.com/8013017/27508934-453cbd12-58f9-11e7-8629-06cd3d0705a9.png)

The algorithm in this pull request will fit most situations, as in most cases only 2 or three events are overlapping.