### PR TITLE
Remove dynamic color

### DIFF
--- a/CalendarKit.podspec
+++ b/CalendarKit.podspec
@@ -12,5 +12,4 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/**/*'
   s.dependency 'DateToolsSwift'
   s.dependency 'Neon'
-  s.dependency 'DynamicColor'
 end

--- a/CalendarKitDemo/CalendarKitDemo/StyleGenerator.swift
+++ b/CalendarKitDemo/CalendarKitDemo/StyleGenerator.swift
@@ -1,5 +1,4 @@
 import CalendarKit
-import DynamicColor
 
 struct StyleGenerator {
   static func defaultStyle() -> CalendarStyle {
@@ -8,7 +7,7 @@ struct StyleGenerator {
 
   static func darkStyle() -> CalendarStyle {
     let orange = UIColor.orange
-    let dark = UIColor(hexString: "1A1A1A")
+    let dark = UIColor(white: 0.1, alpha: 1)
     let light = UIColor.lightGray
     let white = UIColor.white
 

--- a/CalendarKitDemo/Podfile.lock
+++ b/CalendarKitDemo/Podfile.lock
@@ -1,10 +1,8 @@
 PODS:
-  - CalendarKit (0.1.17):
+  - CalendarKit (0.1.19):
     - DateToolsSwift
-    - DynamicColor
     - Neon
   - DateToolsSwift (2.0.3)
-  - DynamicColor (3.3)
   - Neon (0.4.0)
 
 DEPENDENCIES:
@@ -15,9 +13,8 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  CalendarKit: 5f2082e60fb2b74e0772d4085ccede82ce4d57f5
+  CalendarKit: c30b4f91a991d61a8fb6d4220391063e9397791d
   DateToolsSwift: bf69bf9056d9e53c5c03f06e51f219b9b8b02f9e
-  DynamicColor: 3cdaa1e01c16e93ba744e0630f768373e0fc7a7d
   Neon: 7fb5a9327e7e57911843f608e08f4893a74deaf9
 
 PODFILE CHECKSUM: b76013ff0b66b8e61c214e583d26b4c3d93a550b

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ dayView.updateStyle(style)
 ## Dependencies
 - **[Neon](https://github.com/mamaral/Neon)** is used for declarative layout
 - **[DateTools](https://github.com/MatthewYork/DateTools)** is used for date manipulation
-- **[DynamicColor](https://github.com/yannickl/DynamicColor)** is used to update the colors of Events
 
 ## Roadmap
 CalendarKit is under development, API can and will be changed.

--- a/Source/Timeline/Event.swift
+++ b/Source/Timeline/Event.swift
@@ -1,18 +1,19 @@
 import UIKit
 import DateToolsSwift
-import DynamicColor
 
 open class Event: EventDescriptor {
   public var datePeriod = TimePeriod()
   public var text = ""
   public var color = UIColor.blue {
     didSet {
-      textColor = color.darkened(amount: 0.3)
-      backgroundColor = UIColor(red: color.redComponent, green: color.greenComponent, blue: color.blueComponent, alpha: 0.3)
+      backgroundColor = color.withAlphaComponent(0.3)
+      var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+      color.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+      textColor = UIColor(hue: h, saturation: s, brightness: b * 0.4, alpha: a)
     }
   }
-  public var backgroundColor = UIColor()
-  public var textColor = UIColor()
+  public var backgroundColor = UIColor.blue.withAlphaComponent(0.3)
+  public var textColor = UIColor.black
   public var frame = CGRect.zero
   public var userInfo: Any?
   public init() {}


### PR DESCRIPTION
DynamicColor has been used only to calculate colors for the EventView components (text, background, border).
Removing the library allows integrator to use any other library or custom algorithm to set colors, hence providing greater flexibility.