### PR TITLE
Fix empty screen when scrolling, Fix text clipping

### DIFF
--- a/CalendarKit.podspec
+++ b/CalendarKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "CalendarKit"
   s.summary          = "Fully customizable calendar for iOS"
-  s.version          = "0.1.19"
+  s.version          = "0.1.20"
   s.homepage         = "https://github.com/richardtop/CalendarKit"
   s.license          = 'MIT'
   s.author           = { "Richard Topchii" => "richardot4@gmail.com" }

--- a/Source/Timeline/EventView.swift
+++ b/Source/Timeline/EventView.swift
@@ -32,6 +32,7 @@ open class EventView: UIView {
     view.font = UIFont.boldSystemFont(ofSize: 12)
     view.isUserInteractionEnabled = false
     view.backgroundColor = .clear
+    view.isScrollEnabled = false
     return view
   }()
 

--- a/Source/Timeline/TimelinePagerView.swift
+++ b/Source/Timeline/TimelinePagerView.swift
@@ -123,22 +123,18 @@ extension TimelinePagerView: DayViewStateUpdating {
     let newDate = newDate.dateOnly()
     if newDate.isEarlier(than: oldDate) {
       var timelineDate = newDate
-      for (index, timelineContainer) in timelinePager.reusableViews.enumerated() {
+      for timelineContainer in timelinePager.reusableViews {
         timelineContainer.timeline.date = timelineDate
         timelineDate = timelineDate.add(TimeChunk.dateComponents(days: 1))
-        if index == 0 {
-          updateTimeline(timelineContainer.timeline)
-        }
+        updateTimeline(timelineContainer.timeline)
       }
       timelinePager.scrollBackward()
     } else if newDate.isLater(than: oldDate) {
       var timelineDate = newDate
-      for (index, timelineContainer) in timelinePager.reusableViews.reversed().enumerated() {
+      for timelineContainer in timelinePager.reusableViews.reversed() {
         timelineContainer.timeline.date = timelineDate
         timelineDate = timelineDate.subtract(TimeChunk.dateComponents(days: 1))
-        if index == 0 {
-          updateTimeline(timelineContainer.timeline)
-        }
+        updateTimeline(timelineContainer.timeline)
       }
       timelinePager.scrollForward()
     }


### PR DESCRIPTION
1. Fixed bug when sometimes Timeline was empty after user has navigated the calendar
2. Fixed bug when text in `UITextView` could be clipped because of the view reuse.
Relevant SO question:
https://stackoverflow.com/questions/18696706/large-text-being-cut-off-in-uitextview-that-is-inside-uiscrollview