### PR TITLE
Route date selection through state

### DIFF
--- a/CalendarKit.podspec
+++ b/CalendarKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "CalendarKit"
   s.summary          = "Fully customizable calendar for iOS"
-  s.version          = "0.1.20"
+  s.version          = "0.1.21"
   s.homepage         = "https://github.com/richardtop/CalendarKit"
   s.license          = 'MIT'
   s.author           = { "Richard Topchii" => "richardot4@gmail.com" }

--- a/Source/Header/DayHeaderView.swift
+++ b/Source/Header/DayHeaderView.swift
@@ -93,7 +93,7 @@ public class DayHeaderView: UIView {
 }
 
 extension DayHeaderView: DaySelectorDelegate {
-  func dateSelectorDidSelectDate(_ date: Date, index: Int) {
+  func dateSelectorDidSelectDate(_ date: Date) {
     state?.move(to: date)
   }
 }

--- a/Source/Header/DayHeaderView.swift
+++ b/Source/Header/DayHeaderView.swift
@@ -103,13 +103,16 @@ extension DayHeaderView: DayViewStateUpdating {
     let startDate = centerDaySelector.startDate.dateOnly()
 
     let daysFrom = newDate.days(from: startDate, calendar: calendar)
+    let newStartDate = beginningOfWeek(newDate)
 
     if daysFrom < 0 {
-      pagingScrollView.scrollBackward()
+      pagingScrollView.reusableViews[0].startDate = newStartDate
       currentWeekdayIndex = abs(daysInWeek + daysFrom % daysInWeek)
+      pagingScrollView.scrollBackward()
     } else if daysFrom > daysInWeek - 1 {
-      pagingScrollView.scrollForward()
+      pagingScrollView.reusableViews[2].startDate = newStartDate
       currentWeekdayIndex = daysFrom % daysInWeek
+      pagingScrollView.scrollForward()
     } else {
       centerDaySelector.selectedDate = newDate
       currentWeekdayIndex = daysFrom

--- a/Source/Header/DayHeaderView.swift
+++ b/Source/Header/DayHeaderView.swift
@@ -94,8 +94,7 @@ public class DayHeaderView: UIView {
 
 extension DayHeaderView: DaySelectorDelegate {
   func dateSelectorDidSelectDate(_ date: Date, index: Int) {
-    currentWeekdayIndex = index
-    state?.client(client: self, didMoveTo: date)
+    state?.move(to: date)
   }
 }
 
@@ -115,6 +114,7 @@ extension DayHeaderView: DayViewStateUpdating {
       currentWeekdayIndex = daysFrom % daysInWeek
     } else {
       centerDaySelector.selectedDate = newDate
+      currentWeekdayIndex = daysFrom
     }
   }
 }

--- a/Source/Header/DayHeaderView.swift
+++ b/Source/Header/DayHeaderView.swift
@@ -121,15 +121,16 @@ extension DayHeaderView: DayViewStateUpdating {
 }
 
 extension DayHeaderView: PagingScrollViewDelegate {
-  func updateViewAtIndex(_ index: Int) {
-    let viewToUpdate = pagingScrollView.reusableViews[index]
-    let weeksToAdd = index > 1 ? 3 : -3
-    viewToUpdate.startDate = viewToUpdate.startDate.add(TimeChunk.dateComponents(weeks: weeksToAdd))
-  }
-
   func scrollviewDidScrollToViewAtIndex(_ index: Int) {
     let activeView = pagingScrollView.reusableViews[index]
     activeView.selectedIndex = currentWeekdayIndex
+
+    let leftView = pagingScrollView.reusableViews[0]
+    let rightView = pagingScrollView.reusableViews[2]
+
+    leftView.startDate = activeView.startDate.add(TimeChunk.dateComponents(weeks: -1))
+    rightView.startDate = activeView.startDate.add(TimeChunk.dateComponents(weeks: 1))
+
     state?.client(client: self, didMoveTo: activeView.selectedDate!)
   }
 }

--- a/Source/Header/DayHeaderView.swift
+++ b/Source/Header/DayHeaderView.swift
@@ -64,12 +64,10 @@ public class DayHeaderView: UIView {
   }
 
   func beginningOfWeek(_ date: Date) -> Date {
-    var components = calendar.dateComponents([.year, .month, .day,
-                                              .weekday, .timeZone], from: date)
-    let offset = components.weekday! - calendar.firstWeekday
-    components.day = components.day! - offset
-
-    return calendar.date(from: components)!
+    return calendar.date(from: DateComponents(calendar: calendar,
+                                              year: date.year,
+                                              weekday: calendar.firstWeekday,
+                                              weekOfYear: date.weekOfYear))!
   }
 
   public func updateStyle(_ newStyle: DayHeaderStyle) {

--- a/Source/Header/DaySelector.swift
+++ b/Source/Header/DaySelector.swift
@@ -111,11 +111,7 @@ class DaySelector: UIView, ReusableView {
 
   func dateLabelDidTap(_ sender: UITapGestureRecognizer) {
     if let label = sender.view as? DateLabel {
-      selectedIndex = dateLabels.index(of: label)!
       delegate?.dateSelectorDidSelectDate(label.date, index: selectedIndex)
-      dateLabels.filter {$0.selected == true}
-        .first?.selected = false
-      label.selected = true
     }
   }
 }

--- a/Source/Header/DaySelector.swift
+++ b/Source/Header/DaySelector.swift
@@ -3,7 +3,7 @@ import Neon
 import DateToolsSwift
 
 protocol DaySelectorDelegate: class {
-  func dateSelectorDidSelectDate(_ date: Date, index: Int)
+  func dateSelectorDidSelectDate(_ date: Date)
 }
 
 class DaySelector: UIView, ReusableView {
@@ -111,7 +111,7 @@ class DaySelector: UIView, ReusableView {
 
   func dateLabelDidTap(_ sender: UITapGestureRecognizer) {
     if let label = sender.view as? DateLabel {
-      delegate?.dateSelectorDidSelectDate(label.date, index: selectedIndex)
+      delegate?.dateSelectorDidSelectDate(label.date)
     }
   }
 }

--- a/Source/PagingScrollView.swift
+++ b/Source/PagingScrollView.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 protocol PagingScrollViewDelegate: class {
-  func updateViewAtIndex(_ index: Int)
   func scrollviewDidScrollToViewAtIndex(_ index: Int)
 }
 
@@ -75,12 +74,10 @@ class PagingScrollView<T: UIView>: UIScrollView, UIScrollViewDelegate where T: R
       reusableViews.shift(1)
       accumulator += 1
       reusableViews.last!.prepareForReuse()
-      viewDelegate?.updateViewAtIndex(reusableViews.endIndex - 1)
     } else if distanceFromCenter < 0 {
       reusableViews.shift(-1)
       accumulator -= 1
       reusableViews.first!.prepareForReuse()
-      viewDelegate?.updateViewAtIndex(0)
     }
     contentOffset = CGPoint(x: centerOffsetX, y: contentOffset.y)
   }
@@ -101,11 +98,11 @@ class PagingScrollView<T: UIView>: UIScrollView, UIScrollViewDelegate where T: R
   }
 
   func checkForPageChange() {
+    recenter()
     if currentIndex != previousPage {
       viewDelegate?.scrollviewDidScrollToViewAtIndex(Int(currentScrollViewPage))
       previousPage = currentIndex
     }
-    recenter()
   }
 
   func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {

--- a/Source/Timeline/EventView.swift
+++ b/Source/Timeline/EventView.swift
@@ -21,7 +21,7 @@ open class EventView: UIView {
   weak var delegate: EventViewDelegate?
   public var descriptor: EventDescriptor?
 
-  public var color = UIColor()
+  public var color = UIColor.lightGray
 
   var contentHeight: CGFloat {
     return textView.height

--- a/Source/Timeline/TimelinePagerView.swift
+++ b/Source/Timeline/TimelinePagerView.swift
@@ -142,21 +142,25 @@ extension TimelinePagerView: DayViewStateUpdating {
 }
 
 extension TimelinePagerView: PagingScrollViewDelegate {
-  func updateViewAtIndex(_ index: Int) {
-    let timeline = timelinePager.reusableViews[index].timeline
-    let amount = index > 1 ? 1 : -1
-    guard let state = state
-      else{ return }
-    timeline?.date = state.selectedDate.add(TimeChunk.dateComponents(days: amount))
-    updateTimeline(timeline!)
-  }
-
   func scrollviewDidScrollToViewAtIndex(_ index: Int) {
     let nextDate = timelinePager.reusableViews[index].timeline.date
     delegate?.timelinePager(timelinePager: self, willMoveTo: nextDate)
     state?.client(client: self, didMoveTo: nextDate)
     scrollToFirstEventIfNeeded()
     delegate?.timelinePager(timelinePager: self, didMoveTo: nextDate)
+
+    // Update left & right views
+
+    let leftView = timelinePager.reusableViews[0].timeline!
+    let rightView = timelinePager.reusableViews[2].timeline!
+
+    guard let state = state
+      else{ return }
+
+    leftView.date = state.selectedDate.add(TimeChunk.dateComponents(days: -1))
+    rightView.date = state.selectedDate.add(TimeChunk.dateComponents(days: 1))
+
+    [leftView, rightView].forEach{self.updateTimeline($0)}
   }
 
   func scrollToFirstEventIfNeeded() {


### PR DESCRIPTION
1. Route date selection through state (in header):
Now selecting a particular day in header triggers method call in `DayViewState` which updates the header.
This change fixed bugs #71, #55, #77. Now it is possible to configure DayView with any desired date  as well as jump between dates.
2. Fix for #75 by setting default color for the event.