### PR TITLE
12/24 hour support

### DIFF
--- a/Source/CalendarStyle.swift
+++ b/Source/CalendarStyle.swift
@@ -1,3 +1,16 @@
+
+
+public enum DateStyle {
+    ///Times should be shown in the 12 hour format
+    case twelveHour
+    
+    ///Times should be shown in the 24 hour format
+    case twentyFourHour
+    
+    ///Times should be shown according to the user's system preference.
+    case system
+}
+
 public class CalendarStyle: NSCopying {
   public var header = DayHeaderStyle()
   public var timeline = TimelineStyle()
@@ -89,7 +102,7 @@ public class TimelineStyle: NSCopying {
   public var lineColor = UIColor.lightGray
   public var backgroundColor = UIColor.white
   public var font = UIFont.boldSystemFont(ofSize: 11)
-  public var show24Hour = Locale.current.uses24hClock()
+  public var dateStyle : DateStyle = .system
   public init() {}
   public func copy(with zone: NSZone? = nil) -> Any {
     let copy = TimelineStyle()
@@ -98,7 +111,7 @@ public class TimelineStyle: NSCopying {
     copy.lineColor = lineColor
     copy.backgroundColor = backgroundColor
     copy.font = font
-    copy.show24Hour = show24Hour
+    copy.dateStyle = dateStyle
     return copy
   }
 }
@@ -106,13 +119,13 @@ public class TimelineStyle: NSCopying {
 public class CurrentTimeIndicatorStyle: NSCopying {
   public var color = UIColor.red
   public var font = UIFont.systemFont(ofSize: 11)
-  public var show24Hour = Locale.current.uses24hClock()
+  public var dateStyle : DateStyle = .system
   public init() {}
   public func copy(with zone: NSZone? = nil) -> Any {
     let copy = CurrentTimeIndicatorStyle()
     copy.color = color
     copy.font = font
-    copy.show24Hour = show24Hour
+    copy.dateStyle = dateStyle
     return copy
   }
 }

--- a/Source/CalendarStyle.swift
+++ b/Source/CalendarStyle.swift
@@ -89,6 +89,7 @@ public class TimelineStyle: NSCopying {
   public var lineColor = UIColor.lightGray
   public var backgroundColor = UIColor.white
   public var font = UIFont.boldSystemFont(ofSize: 11)
+  public var show24Hour = Locale.current.uses24hClock()
   public init() {}
   public func copy(with zone: NSZone? = nil) -> Any {
     let copy = TimelineStyle()
@@ -97,6 +98,7 @@ public class TimelineStyle: NSCopying {
     copy.lineColor = lineColor
     copy.backgroundColor = backgroundColor
     copy.font = font
+    copy.show24Hour = show24Hour
     return copy
   }
 }
@@ -104,11 +106,13 @@ public class TimelineStyle: NSCopying {
 public class CurrentTimeIndicatorStyle: NSCopying {
   public var color = UIColor.red
   public var font = UIFont.systemFont(ofSize: 11)
+  public var show24Hour = Locale.current.uses24hClock()
   public init() {}
   public func copy(with zone: NSZone? = nil) -> Any {
     let copy = CurrentTimeIndicatorStyle()
     copy.color = color
     copy.font = font
+    copy.show24Hour = show24Hour
     return copy
   }
 }

--- a/Source/Extensions/Locale+24Hour.swift
+++ b/Source/Extensions/Locale+24Hour.swift
@@ -1,0 +1,25 @@
+//
+//  Calendar+24Hour.swift
+//  Pods
+//
+//  Created by James Webster on 06/09/2017.
+//
+//
+
+import Foundation
+
+extension Locale {
+    
+    /// Returns true if this locale uses a 24 hour time format
+    ///
+    /// - Returns: true if this locale uses a 24 hour time format
+    func uses24hClock() -> Bool {
+        
+        //[j] is a special-purpose symbol. It must not occur in pattern or skeleton data. Instead, it is reserved for use in skeletons passed to APIs doing flexible date pattern generation. In such a context, it requests the preferred hour format for the locale (h, H, K, or k), as determined by whether h, H, K, or k is used in the standard short time format for the locale. In the implementation of such an API, 'j' must be replaced by h, H, K, or k before beginning a match against availableFormats data. Note that use of 'j' in a skeleton passed to an API is the only way to have a skeleton request a locale's preferred time cycle type (12-hour or 24-hour).
+        //http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_Patterns
+        
+        let formatter = DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: self) ?? ""
+        return !formatter.contains("a")
+    }
+    
+}

--- a/Source/Extensions/Locale+24Hour.swift
+++ b/Source/Extensions/Locale+24Hour.swift
@@ -1,25 +1,16 @@
-//
-//  Calendar+24Hour.swift
-//  Pods
-//
-//  Created by James Webster on 06/09/2017.
-//
-//
-
 import Foundation
 
 extension Locale {
     
-    /// Returns true if this locale uses a 24 hour time format
-    ///
-    /// - Returns: true if this locale uses a 24 hour time format
-    func uses24hClock() -> Bool {
+  /// Returns true if this locale uses a 24 hour time format
+  ///
+  /// - Returns: true if this locale uses a 24 hour time format
+  func uses24hClock() -> Bool {
+    //[j] is a special-purpose symbol. It must not occur in pattern or skeleton data. Instead, it is reserved for use in skeletons passed to APIs doing flexible date pattern generation. In such a context, it requests the preferred hour format for the locale (h, H, K, or k), as determined by whether h, H, K, or k is used in the standard short time format for the locale. In the implementation of such an API, 'j' must be replaced by h, H, K, or k before beginning a match against availableFormats data. Note that use of 'j' in a skeleton passed to an API is the only way to have a skeleton request a locale's preferred time cycle type (12-hour or 24-hour).
+    //http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_Patterns
         
-        //[j] is a special-purpose symbol. It must not occur in pattern or skeleton data. Instead, it is reserved for use in skeletons passed to APIs doing flexible date pattern generation. In such a context, it requests the preferred hour format for the locale (h, H, K, or k), as determined by whether h, H, K, or k is used in the standard short time format for the locale. In the implementation of such an API, 'j' must be replaced by h, H, K, or k before beginning a match against availableFormats data. Note that use of 'j' in a skeleton passed to an API is the only way to have a skeleton request a locale's preferred time cycle type (12-hour or 24-hour).
-        //http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_Patterns
-        
-        let formatter = DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: self) ?? ""
-        return !formatter.contains("a")
-    }
+    let formatter = DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: self) ?? ""
+    return !formatter.contains("a")
+  }
     
 }

--- a/Source/Timeline/CurrentTimeIndicator.swift
+++ b/Source/Timeline/CurrentTimeIndicator.swift
@@ -77,6 +77,17 @@ class CurrentTimeIndicator: UIView {
     timeLabel.font = style.font
     circle.backgroundColor = style.color
     line.backgroundColor = style.color
-    is24hClock = style.show24Hour
+    
+    switch style.dateStyle {
+    case .twelveHour:
+        is24hClock = false
+        break
+    case .twentyFourHour:
+        is24hClock = true
+        break
+    default:
+        is24hClock = Locale.autoupdatingCurrent.uses24hClock()
+        break
+    }
   }
 }

--- a/Source/Timeline/CurrentTimeIndicator.swift
+++ b/Source/Timeline/CurrentTimeIndicator.swift
@@ -2,17 +2,20 @@ import UIKit
 import Neon
 
 class CurrentTimeIndicator: UIView {
-
+    
+  let padding : CGFloat = 5
   var leftInset: CGFloat = 53
 
-  var is24hClock = true
+  /// Determines if times should be displayed in a 24 hour format. Defaults to the current locale's setting
+  var is24hClock : Bool = true {
+    didSet {
+      updateDate()
+    }
+  }
 
   var date = Date() {
     didSet {
-      let dateFormat = is24hClock ? "HH:mm" : "h:mm a"
-      timeLabel.text = date.format(with: dateFormat)
-      timeLabel.sizeToFit()
-      setNeedsLayout()
+      updateDate()
     }
   }
 
@@ -36,14 +39,32 @@ class CurrentTimeIndicator: UIView {
     [timeLabel, circle, line].forEach {
       addSubview($0)
     }
+    
+    //Allow label to adjust so that am/pm can be displayed if format is changed.
+    timeLabel.numberOfLines = 1
+    timeLabel.adjustsFontSizeToFitWidth = true
+    timeLabel.minimumScaleFactor = 0.5
+    
+    //The width of the label is determined by leftInset and padding. 
+    //The y position is determined by the line's middle.
+    timeLabel.translatesAutoresizingMaskIntoConstraints = false
+    timeLabel.widthAnchor.constraint(equalToConstant: leftInset - (3 * padding)).isActive = true
+    timeLabel.rightAnchor.constraint(equalTo: line.leftAnchor, constant: -padding).isActive = true
+    timeLabel.centerYAnchor.constraint(equalTo: line.centerYAnchor).isActive = true
+    timeLabel.baselineAdjustment = .alignCenters
+    
     updateStyle(style)
+  }
+    
+  func updateDate() {
+    let dateFormat = is24hClock ? "HH:mm" : "h:mm a"
+    timeLabel.text = date.format(with: dateFormat)
+    timeLabel.sizeToFit()
+    setNeedsLayout()
   }
 
   override func layoutSubviews() {
-    let size = timeLabel.frame.size
-    timeLabel.align(Align.toTheLeftCentered, relativeTo: line, padding: 5, width: size.width, height: size.height)
-
-    line.frame = CGRect(x: leftInset - 5, y: bounds.height / 2, width: bounds.width, height: 1)
+    line.frame = CGRect(x: leftInset - padding, y: bounds.height / 2, width: bounds.width, height: 1)
 
     circle.frame = CGRect(x: leftInset + 1, y: 0, width: 6, height: 6)
     circle.center.y = line.center.y
@@ -56,5 +77,6 @@ class CurrentTimeIndicator: UIView {
     timeLabel.font = style.font
     circle.backgroundColor = style.color
     line.backgroundColor = style.color
+    is24hClock = style.show24Hour
   }
 }

--- a/Source/Timeline/EventView.swift
+++ b/Source/Timeline/EventView.swift
@@ -58,7 +58,6 @@ open class EventView: UIView {
   }
 
   func updateWithDescriptor(event: EventDescriptor) {
-    print (event.font)
     descriptor = event
     textView.text = event.text
     textView.textColor = event.textColor

--- a/Source/Timeline/EventView.swift
+++ b/Source/Timeline/EventView.swift
@@ -58,6 +58,7 @@ open class EventView: UIView {
   }
 
   func updateWithDescriptor(event: EventDescriptor) {
+    print (event.font)
     descriptor = event
     textView.text = event.text
     textView.textColor = event.textColor

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -42,7 +42,7 @@ public class TimelineView: UIView, ReusableView {
 
   var style = TimelineStyle()
 
-  var verticalDiff: CGFloat = 100
+  var verticalDiff: CGFloat = 45
   var verticalInset: CGFloat = 10
   var leftInset: CGFloat = 53
 

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -115,6 +115,7 @@ public class TimelineView: UIView, ReusableView {
   public func updateStyle(_ newStyle: TimelineStyle) {
     style = newStyle.copy() as! TimelineStyle
     nowLine.updateStyle(style.timeIndicator)
+    is24hClock = style.show24Hour
     backgroundColor = style.backgroundColor
     setNeedsDisplay()
   }

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -42,7 +42,7 @@ public class TimelineView: UIView, ReusableView {
 
   var style = TimelineStyle()
 
-  var verticalDiff: CGFloat = 45
+  var verticalDiff: CGFloat = 100
   var verticalInset: CGFloat = 10
   var leftInset: CGFloat = 53
 
@@ -115,7 +115,19 @@ public class TimelineView: UIView, ReusableView {
   public func updateStyle(_ newStyle: TimelineStyle) {
     style = newStyle.copy() as! TimelineStyle
     nowLine.updateStyle(style.timeIndicator)
-    is24hClock = style.show24Hour
+    
+    switch style.dateStyle {
+      case .twelveHour:
+        is24hClock = false
+        break
+      case .twentyFourHour:
+        is24hClock = true
+        break
+      default:
+        is24hClock = Locale.autoupdatingCurrent.uses24hClock()
+        break
+    }
+    
     backgroundColor = style.backgroundColor
     setNeedsDisplay()
   }


### PR DESCRIPTION
I didn't realise there was already a pull request open for this feature but it appears to have been abandoned anyway.

Although there appeared to be some support for displaying times using 12-hour format, there didn't appear to be any way to modify this value. The format now defaults to the user's current locale but is configurable via the style.