### PR TITLE
All Day Events

### DIFF
--- a/CalendarKitDemo/CalendarKitDemo.xcodeproj/project.pbxproj
+++ b/CalendarKitDemo/CalendarKitDemo.xcodeproj/project.pbxproj
@@ -105,7 +105,6 @@
 				793B14D71BD6815D00961414 /* Frameworks */,
 				793B14D81BD6815D00961414 /* Resources */,
 				B3053EC9A1E73CA47634FC5A /* [CP] Embed Pods Frameworks */,
-				7862427F75AE95B15AE69F50 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -127,7 +126,7 @@
 				TargetAttributes = {
 					793B14D91BD6815D00961414 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = 38LX96JV5Y;
+						DevelopmentTeam = 8U3L6K9JA6;
 						LastSwiftMigration = 0900;
 					};
 				};
@@ -162,21 +161,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		7862427F75AE95B15AE69F50 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CalendarKitDemo/Pods-CalendarKitDemo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		B3053EC9A1E73CA47634FC5A /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -345,7 +329,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 38LX96JV5Y;
+				DEVELOPMENT_TEAM = 8U3L6K9JA6;
 				INFOPLIST_FILE = CalendarKitDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -362,7 +346,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 38LX96JV5Y;
+				DEVELOPMENT_TEAM = 8U3L6K9JA6;
 				INFOPLIST_FILE = CalendarKitDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/CalendarKitDemo/CalendarKitDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/CalendarKitDemo/CalendarKitDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -32,6 +42,16 @@
     },
     {
       "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
       "size" : "29x29",
       "scale" : "1x"
     },
@@ -59,6 +79,16 @@
       "idiom" : "ipad",
       "size" : "76x76",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/CalendarKitDemo/CalendarKitDemo/ExampleController.swift
+++ b/CalendarKitDemo/CalendarKitDemo/ExampleController.swift
@@ -107,7 +107,7 @@ class ExampleController: DayViewController, DatePickerControllerDelegate {
     var date = date.add(TimeChunk.dateComponents(hours: Int(arc4random_uniform(10) + 5)))
     var events = [Event]()
 
-    for i in 0...5 {
+    for i in 0...12 {
       let event = Event()
       let duration = Int(arc4random_uniform(160) + 60)
       let datePeriod = TimePeriod(beginning: date,
@@ -121,6 +121,7 @@ class ExampleController: DayViewController, DatePickerControllerDelegate {
       info.append("\(datePeriod.beginning!.format(with: "HH:mm")) - \(datePeriod.end!.format(with: "HH:mm"))")
       event.text = info.reduce("", {$0 + $1 + "\n"})
       event.color = colors[Int(arc4random_uniform(UInt32(colors.count)))]
+      event.isAllDay = Int(arc4random_uniform(4)) % 2 == 0
       
       // Event styles are updated independently from CalendarStyle
       // hence the need to specify exact colors in case of Dark style

--- a/CalendarKitDemo/CalendarKitDemo/ExampleController.swift
+++ b/CalendarKitDemo/CalendarKitDemo/ExampleController.swift
@@ -107,7 +107,7 @@ class ExampleController: DayViewController, DatePickerControllerDelegate {
     var date = date.add(TimeChunk.dateComponents(hours: Int(arc4random_uniform(10) + 5)))
     var events = [Event]()
 
-    for i in 0...12 {
+    for i in 0...4 {
       let event = Event()
       let duration = Int(arc4random_uniform(160) + 60)
       let datePeriod = TimePeriod(beginning: date,
@@ -121,7 +121,7 @@ class ExampleController: DayViewController, DatePickerControllerDelegate {
       info.append("\(datePeriod.beginning!.format(with: "HH:mm")) - \(datePeriod.end!.format(with: "HH:mm"))")
       event.text = info.reduce("", {$0 + $1 + "\n"})
       event.color = colors[Int(arc4random_uniform(UInt32(colors.count)))]
-      event.isAllDay = Int(arc4random_uniform(4)) % 2 == 0
+      event.isAllDay = Int(arc4random_uniform(2)) % 2 == 0
       
       // Event styles are updated independently from CalendarStyle
       // hence the need to specify exact colors in case of Dark style

--- a/CalendarKitDemo/Podfile.lock
+++ b/CalendarKitDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CalendarKit (0.3.0):
+  - CalendarKit (0.3.1):
     - DateToolsSwift
     - Neon
   - DateToolsSwift (4.0.0)
@@ -8,15 +8,20 @@ PODS:
 DEPENDENCIES:
   - CalendarKit (from `../`)
 
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs.git:
+    - DateToolsSwift
+    - Neon
+
 EXTERNAL SOURCES:
   CalendarKit:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  CalendarKit: 430f5e144ab8507e48467553e9d66ec13e8f5dd6
+  CalendarKit: 45103dd6b062a88bec850a6a15d10ee608d125bf
   DateToolsSwift: 875d97ff9e3a5d54abdd67a269b3f51c757b71ab
   Neon: 7fb5a9327e7e57911843f608e08f4893a74deaf9
 
 PODFILE CHECKSUM: b76013ff0b66b8e61c214e583d26b4c3d93a550b
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.0

--- a/Source/CalendarStyle.swift
+++ b/Source/CalendarStyle.swift
@@ -129,3 +129,18 @@ public class CurrentTimeIndicatorStyle: NSCopying {
     return copy
   }
 }
+
+public class AllDayStyle: NSCopying {
+  public var backgroundColor: UIColor = UIColor.lightGray
+  public var allDayFont = UIFont.systemFont(ofSize: 12.0)
+  public var allDayColor: UIColor = UIColor.black
+  
+  public func copy(with zone: NSZone? = nil) -> Any {
+    let copy = AllDayStyle()
+    copy.allDayColor = allDayColor
+    copy.backgroundColor = backgroundColor
+    copy.allDayFont = allDayFont
+    
+    return copy
+  }
+}

--- a/Source/Extensions/View+StackView.swift
+++ b/Source/Extensions/View+StackView.swift
@@ -1,0 +1,30 @@
+//
+//  View+StackView.swift
+//  CalendarKit
+//
+//  Created by Erick Sanchez on 5/10/18.
+//
+
+import UIKit
+
+extension UIStackView {
+  
+  /**
+   <#Lorem ipsum dolor sit amet.#>
+   
+   - parameter <#bar#>: <#Consectetur adipisicing elit.#>
+   
+   - returns: <#Sed do eiusmod tempor.#>
+   */
+  convenience init(axis: UILayoutConstraintAxis = .vertical,
+                   distribution: UIStackViewDistribution = .fill,
+                   alignment: UIStackViewAlignment = .fill,
+                   spacing: CGFloat = 0,
+                   subviews: [UIView] = []) {
+    self.init(arrangedSubviews: subviews)
+    self.axis = axis
+    self.distribution = distribution
+    self.alignment = alignment
+    self.spacing = spacing
+  }
+}

--- a/Source/Extensions/View+StackView.swift
+++ b/Source/Extensions/View+StackView.swift
@@ -9,13 +9,6 @@ import UIKit
 
 extension UIStackView {
   
-  /**
-   <#Lorem ipsum dolor sit amet.#>
-   
-   - parameter <#bar#>: <#Consectetur adipisicing elit.#>
-   
-   - returns: <#Sed do eiusmod tempor.#>
-   */
   convenience init(axis: UILayoutConstraintAxis = .vertical,
                    distribution: UIStackViewDistribution = .fill,
                    alignment: UIStackViewAlignment = .fill,

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -15,16 +15,16 @@ public class AllDayView: UIView {
   
   private(set) lazy var scrollView: UIScrollView = {
     let sv = UIScrollView(frame: CGRect.zero)
+    sv.translatesAutoresizingMaskIntoConstraints = false
     addSubview(sv)
     
     sv.isScrollEnabled = true
     sv.alwaysBounceVertical = true
     sv.clipsToBounds = false
     
-    sv.translatesAutoresizingMaskIntoConstraints = false
-    sv.leftAnchor.constraint(equalTo: leftAnchor, constant: allDayLabelWidth).isActive = true
+    sv.leadingAnchor.constraint(equalTo: leadingAnchor, constant: allDayLabelWidth).isActive = true
     sv.topAnchor.constraint(equalTo: topAnchor, constant: 2).isActive = true
-    sv.rightAnchor.constraint(equalTo: rightAnchor, constant: 0).isActive = true
+    sv.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0).isActive = true
     bottomAnchor.constraint(equalTo: sv.bottomAnchor, constant: 2).isActive = true
     
     let maxAllDayViewHeight = allDayEventHeight * 2 + allDayEventHeight * 0.5
@@ -58,6 +58,10 @@ public class AllDayView: UIView {
   public func reloadData() {
     guard let dataSource = self.dataSource else {
       return
+    }
+    
+    defer {
+      layoutIfNeeded()
     }
     
     // clear subviews TODO: clear out only contents of scroll view

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -1,10 +1,3 @@
-//
-//  AllDayView.swift
-//  workspace
-//
-//  Created by Erick Sanchez on 4/28/18.
-//  Copyright © 2018 LinnierGames. All rights reserved.
-//
 
 import UIKit
 
@@ -34,7 +27,7 @@ public class AllDayView: UIView {
   // MARK: - METHODS
   
   private func configure() {
-    
+    backgroundColor = UIColor.gray
     reloadData()
   }
   
@@ -43,24 +36,72 @@ public class AllDayView: UIView {
       return
     }
     
+    // clear subviews TODO: clear out only contents of scroll view
+    subviews.forEach { $0.removeFromSuperview() }
+    
     let nEventDescriptors = dataSource.numberOfAllDayEvents(in: self)
     if nEventDescriptors == 0 || nEventDescriptors < 0 { return }
     
-    // create vertical stack view
+    //TODO: add All-Day UILabel
     
-    for index in 0...nEventDescriptors {
+    //TODO: remove local vars by using properties
+    let allDayLabelWidth: CGFloat = 53.0
+    let scrollViewWidth: CGFloat = bounds.width - allDayLabelWidth
+    let eventViewHeight: CGFloat = 32.0
+    
+    // create vertical stack view
+    let verticalStackView = UIStackView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+    verticalStackView.distribution = .fillEqually
+    verticalStackView.axis = .vertical
+    verticalStackView.spacing = 1.0
+    var horizontalStackView: UIStackView! = nil
+    
+    for index in 0...nEventDescriptors - 1 {
       let eventDescriptor = dataSource.allDayView(self, eventDescriptorFor: index)
       
       // create event TODO: reuse event views
+      let eventRect = CGRect(x: 0, y: 0, width: 10, height: 10)
+      let eventView = EventView(frame: eventRect)
+      eventView.updateWithDescriptor(event: eventDescriptor)
       
       // create horz stack view if index % 2 == 0
+      if index % 2 == 0 {
+        horizontalStackView = UIStackView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+        horizontalStackView.axis = .horizontal
+        horizontalStackView.distribution = .fillEqually
+        horizontalStackView.spacing = 1.0
+        verticalStackView.addArrangedSubview(horizontalStackView)
+      }
       
       // add eventView to horz. stack view
+      horizontalStackView.addArrangedSubview(eventView)
     }
     
-    // create scroll view, vert. stack view inside, update content view
+    let nHorizontalStackViews: Int = nEventDescriptors / 2
     
-    // addSubview(scrollview)
+    // create scroll view, vert. stack view inside, pin vert. stack view, update content view by the number of horz. stack views
+    let scrollViewHeight = min(eventViewHeight * 2 + eventViewHeight * 0.5, CGFloat(nHorizontalStackViews) * eventViewHeight)
+    let scrollview = UIScrollView(frame: CGRect(x: allDayLabelWidth, y: 0, width: scrollViewWidth, height: scrollViewHeight))
+    scrollview.isScrollEnabled = true
+    scrollview.alwaysBounceVertical = true
+    scrollview.addSubview(verticalStackView)
+    verticalStackView.translatesAutoresizingMaskIntoConstraints = false
+    verticalStackView.trailingAnchor.constraint(equalTo: scrollview.trailingAnchor, constant: 0).isActive = true
+    verticalStackView.topAnchor.constraint(equalTo: scrollview.topAnchor, constant: 0).isActive = true
+    verticalStackView.leadingAnchor.constraint(equalTo: scrollview.leadingAnchor, constant: 0).isActive = true
+    verticalStackView.bottomAnchor.constraint(equalTo: scrollview.bottomAnchor, constant: 0).isActive = true
+    verticalStackView.widthAnchor.constraint(equalTo: scrollview.widthAnchor, multiplier: 1).isActive = true
+    verticalStackView.heightAnchor.constraint(equalToConstant: CGFloat(nHorizontalStackViews) * (eventViewHeight + 1))
+    scrollview.heightAnchor.constraint(equalTo: verticalStackView.heightAnchor, multiplier: 1).isActive = true
+//    verticalStackView.heightAnchor.constraint(equalTo: scrollview.heightAnchor, multiplier: 1).isActive = true
+//    scrollview.contentSize = CGSize(width: scrollViewWidth, height: )
+    
+    addSubview(scrollview)
+    scrollview.translatesAutoresizingMaskIntoConstraints = false
+    scrollview.leftAnchor.constraint(equalTo: leftAnchor, constant: allDayLabelWidth).isActive = true
+    scrollview.topAnchor.constraint(equalTo: topAnchor, constant: 0.0).isActive = true
+    scrollview.rightAnchor.constraint(equalTo: rightAnchor, constant: 0).isActive = true
+    scrollview.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0).isActive = true
   }
   
   // MARK: - IBACTIONS/IBOUTLETS

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -22,7 +22,43 @@ public class AllDayView: UIView {
     sv.alwaysBounceVertical = true
     sv.clipsToBounds = false
     
-    sv.leadingAnchor.constraint(equalTo: leadingAnchor, constant: allDayLabelWidth).isActive = true
+    let svLeftConstraint = sv.leadingAnchor.constraint(equalTo: leadingAnchor, constant: allDayLabelWidth)
+    
+    /**
+     Why is this constraint 999?
+     
+     Since AllDayView and its constraints are set to its superview and layed out
+     before the superview's width is updated from 0 to it's computed width (screen width),
+     this constraint produces conflicts. Thus, allowing this constraint to be broken
+     prevents conflicts trying to layout this view with the superview.width = 0
+     
+     More on this:
+     this scope of code is first invoked here:
+     
+     ````
+     @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
+     ...
+     public var layoutAttributes: [EventLayoutAttributes] {
+        ...
+        allDayView.reloadData()
+        ...
+     }
+     ````
+     
+     the superview.width is calcuated here:
+     
+     ````
+     @@ public class TimelineContainer: UIScrollView, ReusableView {
+     ...
+     override public func layoutSubviews() {
+        timeline.frame = CGRect(x: 0, y: 0, width: width, height: timeline.fullHeight)
+        ...
+     }
+     ````
+     */
+    svLeftConstraint.priority = UILayoutPriority(rawValue: 999)
+    
+    svLeftConstraint.isActive = true
     sv.topAnchor.constraint(equalTo: topAnchor, constant: 2).isActive = true
     sv.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
     bottomAnchor.constraint(equalTo: sv.bottomAnchor, constant: 2).isActive = true
@@ -58,6 +94,10 @@ public class AllDayView: UIView {
   public func reloadData() {
     guard let dataSource = self.dataSource else {
       return
+    }
+    
+    defer {
+      layoutIfNeeded()
     }
     
     // clear subviews TODO: clear out only contents of scroll view
@@ -112,7 +152,7 @@ public class AllDayView: UIView {
   }
   
   public func scrollToBottom() {
-    let bottomOffset = CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.size.height);
+    let bottomOffset = CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.size.height)
     scrollView.setContentOffset(bottomOffset, animated: false)
   }
   

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -27,7 +27,8 @@ public class AllDayView: UIView {
   // MARK: - METHODS
   
   private func configure() {
-    backgroundColor = UIColor.gray
+    backgroundColor = UIColor.lightGray
+    clipsToBounds = true
     reloadData()
   }
   
@@ -46,8 +47,8 @@ public class AllDayView: UIView {
     
     //TODO: remove local vars by using properties
     let allDayLabelWidth: CGFloat = 53.0
-    let scrollViewWidth: CGFloat = bounds.width - allDayLabelWidth
-    let eventViewHeight: CGFloat = 32.0
+//    let scrollViewWidth: CGFloat = bounds.width - allDayLabelWidth
+    let allDayEventHeight: CGFloat = 24.0
     
     // create vertical stack view
     let verticalStackView = UIStackView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
@@ -60,9 +61,9 @@ public class AllDayView: UIView {
       let eventDescriptor = dataSource.allDayView(self, eventDescriptorFor: index)
       
       // create event TODO: reuse event views
-      let eventRect = CGRect(x: 0, y: 0, width: 10, height: 10)
-      let eventView = EventView(frame: eventRect)
+      let eventView = EventView(frame: CGRect.zero)
       eventView.updateWithDescriptor(event: eventDescriptor)
+      eventView.heightAnchor.constraint(equalToConstant: allDayEventHeight).isActive = true
       
       // create horz stack view if index % 2 == 0
       if index % 2 == 0 {
@@ -77,31 +78,35 @@ public class AllDayView: UIView {
       horizontalStackView.addArrangedSubview(eventView)
     }
     
-    let nHorizontalStackViews: Int = nEventDescriptors / 2
+//    let nHorizontalStackViews: Int = nEventDescriptors / 2
     
     // create scroll view, vert. stack view inside, pin vert. stack view, update content view by the number of horz. stack views
-    let scrollViewHeight = min(eventViewHeight * 2 + eventViewHeight * 0.5, CGFloat(nHorizontalStackViews) * eventViewHeight)
-    let scrollview = UIScrollView(frame: CGRect(x: allDayLabelWidth, y: 0, width: scrollViewWidth, height: scrollViewHeight))
+    let scrollview = UIScrollView(frame: CGRect.zero)
     scrollview.isScrollEnabled = true
     scrollview.alwaysBounceVertical = true
+    scrollview.clipsToBounds = false
     scrollview.addSubview(verticalStackView)
+    
     verticalStackView.translatesAutoresizingMaskIntoConstraints = false
     verticalStackView.trailingAnchor.constraint(equalTo: scrollview.trailingAnchor, constant: 0).isActive = true
     verticalStackView.topAnchor.constraint(equalTo: scrollview.topAnchor, constant: 0).isActive = true
     verticalStackView.leadingAnchor.constraint(equalTo: scrollview.leadingAnchor, constant: 0).isActive = true
     verticalStackView.bottomAnchor.constraint(equalTo: scrollview.bottomAnchor, constant: 0).isActive = true
     verticalStackView.widthAnchor.constraint(equalTo: scrollview.widthAnchor, multiplier: 1).isActive = true
-    verticalStackView.heightAnchor.constraint(equalToConstant: CGFloat(nHorizontalStackViews) * (eventViewHeight + 1))
-    scrollview.heightAnchor.constraint(equalTo: verticalStackView.heightAnchor, multiplier: 1).isActive = true
-//    verticalStackView.heightAnchor.constraint(equalTo: scrollview.heightAnchor, multiplier: 1).isActive = true
-//    scrollview.contentSize = CGSize(width: scrollViewWidth, height: )
+    let verticalStackViewHeightConstraint = verticalStackView.heightAnchor.constraint(equalTo: scrollview.heightAnchor, multiplier: 1)
+    verticalStackViewHeightConstraint.priority = UILayoutPriority(rawValue: 999)
+    verticalStackViewHeightConstraint.isActive = true
     
     addSubview(scrollview)
+    
     scrollview.translatesAutoresizingMaskIntoConstraints = false
     scrollview.leftAnchor.constraint(equalTo: leftAnchor, constant: allDayLabelWidth).isActive = true
-    scrollview.topAnchor.constraint(equalTo: topAnchor, constant: 0.0).isActive = true
+    scrollview.topAnchor.constraint(equalTo: topAnchor, constant: 2).isActive = true
     scrollview.rightAnchor.constraint(equalTo: rightAnchor, constant: 0).isActive = true
-    scrollview.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0).isActive = true
+    bottomAnchor.constraint(equalTo: scrollview.bottomAnchor, constant: 2).isActive = true
+    
+    let maxAllDayViewHeight = allDayEventHeight * 2 + allDayEventHeight * 0.5
+    heightAnchor.constraint(lessThanOrEqualToConstant: maxAllDayViewHeight).isActive = true
   }
   
   // MARK: - IBACTIONS/IBOUTLETS

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -87,6 +87,14 @@ public class AllDayView: UIView {
   private func configure() {
     backgroundColor = UIColor.lightGray
     clipsToBounds = true
+    
+    //add All-Day UILabel
+    let textLayer = CATextLayer()
+    textLayer.string = "all-day"
+    textLayer.frame = CGRect(x: 8.0, y: 4.0, width: allDayLabelWidth, height: 28.0)
+    textLayer.foregroundColor = UIColor.black.cgColor
+    textLayer.fontSize = 12.0
+    layer.addSublayer(textLayer)
   }
   
   public func reloadData() {
@@ -98,8 +106,6 @@ public class AllDayView: UIView {
     scrollView.subviews.forEach { $0.removeFromSuperview() }
     
     if self.events.count == 0 { return }
-    
-    //TODO: add All-Day UILabel
     
     // create vertical stack view
     let verticalStackView = UIStackView(

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -1,0 +1,70 @@
+//
+//  AllDayView.swift
+//  workspace
+//
+//  Created by Erick Sanchez on 4/28/18.
+//  Copyright © 2018 LinnierGames. All rights reserved.
+//
+
+import UIKit
+
+public protocol AllDayViewDataSource {
+  func numberOfAllDayEvents(in allDayView: AllDayView) -> Int
+  func allDayView(_ allDayView: AllDayView, eventDescriptorFor index: Int) -> EventDescriptor
+}
+
+public class AllDayView: UIView {
+  
+  public var dataSource: AllDayViewDataSource?
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    
+    configure()
+  }
+  
+  required public init?(coder aDecoder: NSCoder) {
+    super.init(coder: aDecoder)
+    
+    configure()
+  }
+  
+  // MARK: - RETURN VALUES
+  
+  // MARK: - METHODS
+  
+  private func configure() {
+    
+    reloadData()
+  }
+  
+  public func reloadData() {
+    guard let dataSource = self.dataSource else {
+      return
+    }
+    
+    let nEventDescriptors = dataSource.numberOfAllDayEvents(in: self)
+    if nEventDescriptors == 0 || nEventDescriptors < 0 { return }
+    
+    // create vertical stack view
+    
+    for index in 0...nEventDescriptors {
+      let eventDescriptor = dataSource.allDayView(self, eventDescriptorFor: index)
+      
+      // create event TODO: reuse event views
+      
+      // create horz stack view if index % 2 == 0
+      
+      // add eventView to horz. stack view
+    }
+    
+    // create scroll view, vert. stack view inside, update content view
+    
+    // addSubview(scrollview)
+  }
+  
+  // MARK: - IBACTIONS/IBOUTLETS
+  
+  // MARK: - LIFE CYCLE
+
+}

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -15,6 +15,14 @@ public class AllDayView: UIView {
       self.reloadData()
     }
   }
+  
+  private lazy var textLabel: UILabel = {
+    let label = UILabel(frame: CGRect(x: 8.0, y: 4.0, width: allDayLabelWidth, height: 24.0))
+    label.text = "all-day"
+    label.autoresizingMask = [.flexibleWidth]
+    
+    return label
+  }()
 
   /**
    vertical scroll view that contains the all day events in rows with only 2
@@ -101,22 +109,21 @@ public class AllDayView: UIView {
     scrollView.setContentOffset(bottomOffset, animated: animated)
   }
   
-  public func updateStyle(_ newStyle: TimelineStyle) {
+  public func updateStyle(_ newStyle: AllDayStyle) {
+    style = newStyle.copy() as! AllDayStyle
     
+    backgroundColor = style.backgroundColor
+    textLabel.font = style.allDayFont
+    textLabel.textColor = style.allDayColor
   }
   
   private func configure() {
-    backgroundColor = style.backgroundColor
     clipsToBounds = true
     
     //add All-Day UILabel
-    let textLabel = UILabel(frame: CGRect(x: 8.0, y: 4.0, width: allDayLabelWidth, height: 24.0))
-    textLabel.text = "all-day"
-    textLabel.font = style.allDayFont
-    textLabel.textColor = style.allDayColor
-    
-    textLabel.autoresizingMask = [.flexibleWidth]
     addSubview(textLabel)
+    
+    updateStyle(self.style)
   }
   
   public func reloadData() {

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -5,6 +5,8 @@ public class AllDayView: UIView {
   
   internal weak var eventViewDelegate: EventViewDelegate?
   
+  var style = AllDayStyle()
+  
   let allDayLabelWidth: CGFloat = 53.0
   let allDayEventHeight: CGFloat = 24.0
   
@@ -13,6 +15,7 @@ public class AllDayView: UIView {
       self.reloadData()
     }
   }
+
   /**
    vertical scroll view that contains the all day events in rows with only 2
    columns at most
@@ -89,14 +92,28 @@ public class AllDayView: UIView {
   
   // MARK: - METHODS
   
+  /**
+   scrolls the contentOffset of the scroll view containg the event views to the
+   bottom
+   */
+  public func scrollToBottom(animated: Bool = false) {
+    let bottomOffset = CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.size.height)
+    scrollView.setContentOffset(bottomOffset, animated: animated)
+  }
+  
+  public func updateStyle(_ newStyle: TimelineStyle) {
+    
+  }
+  
   private func configure() {
-    backgroundColor = UIColor.lightGray
+    backgroundColor = style.backgroundColor
     clipsToBounds = true
     
     //add All-Day UILabel
     let textLabel = UILabel(frame: CGRect(x: 8.0, y: 4.0, width: allDayLabelWidth, height: 24.0))
     textLabel.text = "all-day"
-    textLabel.font = UIFont.systemFont(ofSize: 12.0)
+    textLabel.font = style.allDayFont
+    textLabel.textColor = style.allDayColor
     
     textLabel.autoresizingMask = [.flexibleWidth]
     addSubview(textLabel)
@@ -154,15 +171,6 @@ public class AllDayView: UIView {
     let verticalStackViewHeightConstraint = verticalStackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor, multiplier: 1)
     verticalStackViewHeightConstraint.priority = UILayoutPriority(rawValue: 999)
     verticalStackViewHeightConstraint.isActive = true
-  }
-  
-  /**
-   scrolls the contentOffset of the scroll view containg the event views to the
-   bottom
-   */
-  public func scrollToBottom(animated: Bool = false) {
-    let bottomOffset = CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.size.height)
-    scrollView.setContentOffset(bottomOffset, animated: animated)
   }
   
   // MARK: - LIFE CYCLE

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -14,7 +14,7 @@ public class AllDayView: UIView {
   public var dataSource: AllDayViewDataSource?
   
   private(set) lazy var scrollView: UIScrollView = {
-    let sv = UIScrollView(frame: CGRect.zero)
+    let sv = UIScrollView()
     sv.translatesAutoresizingMaskIntoConstraints = false
     addSubview(sv)
     
@@ -24,7 +24,7 @@ public class AllDayView: UIView {
     
     sv.leadingAnchor.constraint(equalTo: leadingAnchor, constant: allDayLabelWidth).isActive = true
     sv.topAnchor.constraint(equalTo: topAnchor, constant: 2).isActive = true
-    sv.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0).isActive = true
+    sv.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
     bottomAnchor.constraint(equalTo: sv.bottomAnchor, constant: 2).isActive = true
     
     let maxAllDayViewHeight = allDayEventHeight * 2 + allDayEventHeight * 0.5
@@ -60,10 +60,6 @@ public class AllDayView: UIView {
       return
     }
     
-    defer {
-      layoutIfNeeded()
-    }
-    
     // clear subviews TODO: clear out only contents of scroll view
     scrollView.subviews.forEach { $0.removeFromSuperview() }
     
@@ -73,7 +69,7 @@ public class AllDayView: UIView {
     //TODO: add All-Day UILabel
     
     // create vertical stack view
-    let verticalStackView = UIStackView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+    let verticalStackView = UIStackView(frame: CGRect.zero)
     verticalStackView.distribution = .fillEqually
     verticalStackView.axis = .vertical
     verticalStackView.spacing = 1.0
@@ -89,7 +85,8 @@ public class AllDayView: UIView {
       
       // create horz stack view if index % 2 == 0
       if index % 2 == 0 {
-        horizontalStackView = UIStackView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+        horizontalStackView = UIStackView(frame: CGRect.zero)
+        horizontalStackView.translatesAutoresizingMaskIntoConstraints = false
         horizontalStackView.axis = .horizontal
         horizontalStackView.distribution = .fillEqually
         horizontalStackView.spacing = 1.0
@@ -101,9 +98,9 @@ public class AllDayView: UIView {
     }
     
     // add vert. stack view inside, pin vert. stack view, update content view by the number of horz. stack views
+    verticalStackView.translatesAutoresizingMaskIntoConstraints = false
     scrollView.addSubview(verticalStackView)
     
-    verticalStackView.translatesAutoresizingMaskIntoConstraints = false
     verticalStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: 0).isActive = true
     verticalStackView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 0).isActive = true
     verticalStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: 0).isActive = true

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -8,7 +8,30 @@ public protocol AllDayViewDataSource {
 
 public class AllDayView: UIView {
   
+  let allDayLabelWidth: CGFloat = 53.0
+  let allDayEventHeight: CGFloat = 24.0
+  
   public var dataSource: AllDayViewDataSource?
+  
+  private(set) lazy var scrollView: UIScrollView = {
+    let sv = UIScrollView(frame: CGRect.zero)
+    addSubview(sv)
+    
+    sv.isScrollEnabled = true
+    sv.alwaysBounceVertical = true
+    sv.clipsToBounds = false
+    
+    sv.translatesAutoresizingMaskIntoConstraints = false
+    sv.leftAnchor.constraint(equalTo: leftAnchor, constant: allDayLabelWidth).isActive = true
+    sv.topAnchor.constraint(equalTo: topAnchor, constant: 2).isActive = true
+    sv.rightAnchor.constraint(equalTo: rightAnchor, constant: 0).isActive = true
+    bottomAnchor.constraint(equalTo: sv.bottomAnchor, constant: 2).isActive = true
+    
+    let maxAllDayViewHeight = allDayEventHeight * 2 + allDayEventHeight * 0.5
+    heightAnchor.constraint(lessThanOrEqualToConstant: maxAllDayViewHeight).isActive = true
+    
+    return sv
+  }()
 
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -38,17 +61,12 @@ public class AllDayView: UIView {
     }
     
     // clear subviews TODO: clear out only contents of scroll view
-    subviews.forEach { $0.removeFromSuperview() }
+    scrollView.subviews.forEach { $0.removeFromSuperview() }
     
     let nEventDescriptors = dataSource.numberOfAllDayEvents(in: self)
     if nEventDescriptors == 0 || nEventDescriptors < 0 { return }
     
     //TODO: add All-Day UILabel
-    
-    //TODO: remove local vars by using properties
-    let allDayLabelWidth: CGFloat = 53.0
-//    let scrollViewWidth: CGFloat = bounds.width - allDayLabelWidth
-    let allDayEventHeight: CGFloat = 24.0
     
     // create vertical stack view
     let verticalStackView = UIStackView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
@@ -78,35 +96,23 @@ public class AllDayView: UIView {
       horizontalStackView.addArrangedSubview(eventView)
     }
     
-//    let nHorizontalStackViews: Int = nEventDescriptors / 2
-    
-    // create scroll view, vert. stack view inside, pin vert. stack view, update content view by the number of horz. stack views
-    let scrollview = UIScrollView(frame: CGRect.zero)
-    scrollview.isScrollEnabled = true
-    scrollview.alwaysBounceVertical = true
-    scrollview.clipsToBounds = false
-    scrollview.addSubview(verticalStackView)
+    // add vert. stack view inside, pin vert. stack view, update content view by the number of horz. stack views
+    scrollView.addSubview(verticalStackView)
     
     verticalStackView.translatesAutoresizingMaskIntoConstraints = false
-    verticalStackView.trailingAnchor.constraint(equalTo: scrollview.trailingAnchor, constant: 0).isActive = true
-    verticalStackView.topAnchor.constraint(equalTo: scrollview.topAnchor, constant: 0).isActive = true
-    verticalStackView.leadingAnchor.constraint(equalTo: scrollview.leadingAnchor, constant: 0).isActive = true
-    verticalStackView.bottomAnchor.constraint(equalTo: scrollview.bottomAnchor, constant: 0).isActive = true
-    verticalStackView.widthAnchor.constraint(equalTo: scrollview.widthAnchor, multiplier: 1).isActive = true
-    let verticalStackViewHeightConstraint = verticalStackView.heightAnchor.constraint(equalTo: scrollview.heightAnchor, multiplier: 1)
+    verticalStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: 0).isActive = true
+    verticalStackView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 0).isActive = true
+    verticalStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: 0).isActive = true
+    verticalStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: 0).isActive = true
+    verticalStackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, multiplier: 1).isActive = true
+    let verticalStackViewHeightConstraint = verticalStackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor, multiplier: 1)
     verticalStackViewHeightConstraint.priority = UILayoutPriority(rawValue: 999)
     verticalStackViewHeightConstraint.isActive = true
-    
-    addSubview(scrollview)
-    
-    scrollview.translatesAutoresizingMaskIntoConstraints = false
-    scrollview.leftAnchor.constraint(equalTo: leftAnchor, constant: allDayLabelWidth).isActive = true
-    scrollview.topAnchor.constraint(equalTo: topAnchor, constant: 2).isActive = true
-    scrollview.rightAnchor.constraint(equalTo: rightAnchor, constant: 0).isActive = true
-    bottomAnchor.constraint(equalTo: scrollview.bottomAnchor, constant: 2).isActive = true
-    
-    let maxAllDayViewHeight = allDayEventHeight * 2 + allDayEventHeight * 0.5
-    heightAnchor.constraint(lessThanOrEqualToConstant: maxAllDayViewHeight).isActive = true
+  }
+  
+  public func scrollToBottom() {
+    let bottomOffset = CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.size.height);
+    scrollView.setContentOffset(bottomOffset, animated: false)
   }
   
   // MARK: - IBACTIONS/IBOUTLETS

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -13,7 +13,10 @@ public class AllDayView: UIView {
       self.reloadData()
     }
   }
-  
+  /**
+   vertical scroll view that contains the all day events in rows with only 2
+   columns at most
+   */
   private(set) lazy var scrollView: UIScrollView = {
     let sv = UIScrollView()
     sv.translatesAutoresizingMaskIntoConstraints = false
@@ -154,9 +157,13 @@ public class AllDayView: UIView {
     verticalStackViewHeightConstraint.isActive = true
   }
   
-  public func scrollToBottom() {
+  /**
+   scrolls the contentOffset of the scroll view containg the event views to the
+   bottom
+   */
+  public func scrollToBottom(animated: Bool = false) {
     let bottomOffset = CGPoint(x: 0, y: scrollView.contentSize.height - scrollView.bounds.size.height)
-    scrollView.setContentOffset(bottomOffset, animated: false)
+    scrollView.setContentOffset(bottomOffset, animated: animated)
   }
   
   // MARK: - LIFE CYCLE

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -1,17 +1,16 @@
 
 import UIKit
 
-public protocol AllDayViewDataSource {
-  func numberOfAllDayEvents(in allDayView: AllDayView) -> Int
-  func allDayView(_ allDayView: AllDayView, eventDescriptorFor index: Int) -> EventDescriptor
-}
-
 public class AllDayView: UIView {
   
   let allDayLabelWidth: CGFloat = 53.0
   let allDayEventHeight: CGFloat = 24.0
   
-  public var dataSource: AllDayViewDataSource?
+  public var events: [EventDescriptor] = [] {
+    didSet {
+      self.reloadData()
+    }
+  }
   
   private(set) lazy var scrollView: UIScrollView = {
     let sv = UIScrollView()
@@ -68,7 +67,7 @@ public class AllDayView: UIView {
     
     return sv
   }()
-
+  
   override init(frame: CGRect) {
     super.init(frame: frame)
     
@@ -88,14 +87,9 @@ public class AllDayView: UIView {
   private func configure() {
     backgroundColor = UIColor.lightGray
     clipsToBounds = true
-    reloadData()
   }
   
   public func reloadData() {
-    guard let dataSource = self.dataSource else {
-      return
-    }
-    
     defer {
       layoutIfNeeded()
     }
@@ -103,8 +97,7 @@ public class AllDayView: UIView {
     // clear subviews TODO: clear out only contents of scroll view
     scrollView.subviews.forEach { $0.removeFromSuperview() }
     
-    let nEventDescriptors = dataSource.numberOfAllDayEvents(in: self)
-    if nEventDescriptors == 0 || nEventDescriptors < 0 { return }
+    if self.events.count == 0 { return }
     
     //TODO: add All-Day UILabel
     
@@ -115,12 +108,11 @@ public class AllDayView: UIView {
     verticalStackView.spacing = 1.0
     var horizontalStackView: UIStackView! = nil
     
-    for index in 0...nEventDescriptors - 1 {
-      let eventDescriptor = dataSource.allDayView(self, eventDescriptorFor: index)
+    for (index, anEventDescriptor) in self.events.enumerated() {
       
       // create event TODO: reuse event views
       let eventView = EventView(frame: CGRect.zero)
-      eventView.updateWithDescriptor(event: eventDescriptor)
+      eventView.updateWithDescriptor(event: anEventDescriptor)
       eventView.heightAnchor.constraint(equalToConstant: allDayEventHeight).isActive = true
       
       // create horz stack view if index % 2 == 0
@@ -156,8 +148,7 @@ public class AllDayView: UIView {
     scrollView.setContentOffset(bottomOffset, animated: false)
   }
   
-  // MARK: - IBACTIONS/IBOUTLETS
-  
   // MARK: - LIFE CYCLE
-
+  
 }
+

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -68,6 +68,8 @@ public class AllDayView: UIView {
     return sv
   }()
   
+  // MARK: - RETURN VALUES
+  
   override init(frame: CGRect) {
     super.init(frame: frame)
     
@@ -79,8 +81,6 @@ public class AllDayView: UIView {
     
     configure()
   }
-  
-  // MARK: - RETURN VALUES
   
   // MARK: - METHODS
   
@@ -102,10 +102,10 @@ public class AllDayView: UIView {
     //TODO: add All-Day UILabel
     
     // create vertical stack view
-    let verticalStackView = UIStackView(frame: CGRect.zero)
-    verticalStackView.distribution = .fillEqually
-    verticalStackView.axis = .vertical
-    verticalStackView.spacing = 1.0
+    let verticalStackView = UIStackView(
+      distribution: .fillEqually,
+      spacing: 1.0
+    )
     var horizontalStackView: UIStackView! = nil
     
     for (index, anEventDescriptor) in self.events.enumerated() {
@@ -117,11 +117,12 @@ public class AllDayView: UIView {
       
       // create horz stack view if index % 2 == 0
       if index % 2 == 0 {
-        horizontalStackView = UIStackView(frame: CGRect.zero)
+        horizontalStackView = UIStackView(
+          axis: .horizontal,
+          distribution: .fillEqually,
+          spacing: 1.0
+        )
         horizontalStackView.translatesAutoresizingMaskIntoConstraints = false
-        horizontalStackView.axis = .horizontal
-        horizontalStackView.distribution = .fillEqually
-        horizontalStackView.spacing = 1.0
         verticalStackView.addArrangedSubview(horizontalStackView)
       }
       

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -3,6 +3,8 @@ import UIKit
 
 public class AllDayView: UIView {
   
+  internal weak var eventViewDelegate: EventViewDelegate?
+  
   let allDayLabelWidth: CGFloat = 53.0
   let allDayEventHeight: CGFloat = 24.0
   
@@ -94,6 +96,7 @@ public class AllDayView: UIView {
     textLayer.frame = CGRect(x: 8.0, y: 4.0, width: allDayLabelWidth, height: 28.0)
     textLayer.foregroundColor = UIColor.black.cgColor
     textLayer.fontSize = 12.0
+    textLayer.contentsScale = UIScreen.main.scale
     layer.addSublayer(textLayer)
   }
   
@@ -102,7 +105,7 @@ public class AllDayView: UIView {
       layoutIfNeeded()
     }
     
-    // clear subviews TODO: clear out only contents of scroll view
+    // clear event views from scroll view
     scrollView.subviews.forEach { $0.removeFromSuperview() }
     
     if self.events.count == 0 { return }
@@ -116,9 +119,10 @@ public class AllDayView: UIView {
     
     for (index, anEventDescriptor) in self.events.enumerated() {
       
-      // create event TODO: reuse event views
+      // create event
       let eventView = EventView(frame: CGRect.zero)
       eventView.updateWithDescriptor(event: anEventDescriptor)
+      eventView.delegate = self.eventViewDelegate
       eventView.heightAnchor.constraint(equalToConstant: allDayEventHeight).isActive = true
       
       // create horz stack view if index % 2 == 0

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -94,13 +94,12 @@ public class AllDayView: UIView {
     clipsToBounds = true
     
     //add All-Day UILabel
-    let textLayer = CATextLayer()
-    textLayer.string = "all-day"
-    textLayer.frame = CGRect(x: 8.0, y: 4.0, width: allDayLabelWidth, height: 28.0)
-    textLayer.foregroundColor = UIColor.black.cgColor
-    textLayer.fontSize = 12.0
-    textLayer.contentsScale = UIScreen.main.scale
-    layer.addSublayer(textLayer)
+    let textLabel = UILabel(frame: CGRect(x: 8.0, y: 4.0, width: allDayLabelWidth, height: 24.0))
+    textLabel.text = "all-day"
+    textLabel.font = UIFont.systemFont(ofSize: 12.0)
+    
+    textLabel.autoresizingMask = [.flexibleWidth]
+    addSubview(textLabel)
   }
   
   public func reloadData() {

--- a/Source/Timeline/Event.swift
+++ b/Source/Timeline/Event.swift
@@ -3,6 +3,7 @@ import UIKit
 open class Event: EventDescriptor {
   public var startDate = Date()
   public var endDate = Date()
+  public var isAllDay = false
   public var text = ""
   public var attributedText: NSAttributedString?
   public var color = UIColor.blue {

--- a/Source/Timeline/EventDescriptor.swift
+++ b/Source/Timeline/EventDescriptor.swift
@@ -3,6 +3,7 @@ import Foundation
 public protocol EventDescriptor {
   var startDate: Date {get}
   var endDate: Date {get}
+  var isAllDay: Bool {get}
   var text: String {get}
   var attributedText: NSAttributedString? {get}
   var font : UIFont {get}

--- a/Source/Timeline/TimelineContainer.swift
+++ b/Source/Timeline/TimelineContainer.swift
@@ -16,6 +16,18 @@ public class TimelineContainer: UIScrollView, ReusableView {
   override public func layoutSubviews() {
     timeline.frame = CGRect(x: 0, y: 0, width: width, height: timeline.fullHeight)
     timeline.offsetAllDayView(by: contentOffset.y)
+    
+    
+    //adjust the scroll insets
+    let allDayViewHeight = timeline.allDayViewHeight
+    let bottomSafeInset: CGFloat
+    if #available(iOS 11.0, *) {
+      bottomSafeInset = window?.safeAreaInsets.bottom ?? 0
+    } else {
+      bottomSafeInset = 0
+    }
+    scrollIndicatorInsets = UIEdgeInsets(top: allDayViewHeight, left: 0, bottom: bottomSafeInset, right: 0)
+    contentInset = UIEdgeInsets(top: allDayViewHeight, left: 0, bottom: bottomSafeInset, right: 0)
   }
   
   public func prepareForReuse() {

--- a/Source/Timeline/TimelineContainer.swift
+++ b/Source/Timeline/TimelineContainer.swift
@@ -15,6 +15,7 @@ public class TimelineContainer: UIScrollView, ReusableView {
   
   override public func layoutSubviews() {
     timeline.frame = CGRect(x: 0, y: 0, width: width, height: timeline.fullHeight)
+    timeline.updateAllDayView(by: contentOffset.y)
   }
   
   public func prepareForReuse() {

--- a/Source/Timeline/TimelineContainer.swift
+++ b/Source/Timeline/TimelineContainer.swift
@@ -15,7 +15,7 @@ public class TimelineContainer: UIScrollView, ReusableView {
   
   override public func layoutSubviews() {
     timeline.frame = CGRect(x: 0, y: 0, width: width, height: timeline.fullHeight)
-    timeline.updateAllDayView(by: contentOffset.y)
+    timeline.offsetAllDayView(by: contentOffset.y)
   }
   
   public func prepareForReuse() {

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -43,6 +43,7 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
       
       recalculateEventLayout()
       prepareEventViews()
+      layoutAllDayEvents()
       setNeedsLayout()
     }
     get {
@@ -62,21 +63,17 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
     let allDayView = AllDayView(frame: CGRect.zero)
     allDayView.dataSource = self
     
-    return allDayView
-  }()
-  
-  func layoutAllDayEvents() {
-    addSubview(allDayView)
+    insertSubview(allDayView, aboveSubview: nowLine)
+    
     allDayView.translatesAutoresizingMaskIntoConstraints = false
-    allDayView.topAnchor.constraint(equalTo: topAnchor, constant: 0).isActive = true
+    self.allDayViewTopConstraint = allDayView.topAnchor.constraint(equalTo: topAnchor, constant: 0)
+    self.allDayViewTopConstraint!.isActive = true
+    
     allDayView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0).isActive = true
     allDayView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0).isActive = true
     
-    allDayView.reloadData()
-    layoutIfNeeded()
-    
-    allDayView.scrollToBottom()
-  }
+    return allDayView
+  }()
 
   var style = TimelineStyle()
 
@@ -224,7 +221,6 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
   override public func layoutSubviews() {
     super.layoutSubviews()
     recalculateEventLayout()
-    layoutAllDayEvents()
     layoutEvents()
     layoutNowLine()
   }
@@ -251,6 +247,19 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
       let eventView = eventViews[idx]
       eventView.frame = attributes.frame
       eventView.updateWithDescriptor(event: descriptor)
+    }
+  }
+  
+  private var allDayViewTopConstraint: NSLayoutConstraint?
+  func layoutAllDayEvents() {
+    allDayView.reloadData()
+    allDayView.scrollToBottom()
+  }
+  
+  func updateAllDayView(by yValue: CGFloat) {
+    if let topConstraint = self.allDayViewTopConstraint {
+      topConstraint.constant = yValue
+      layoutIfNeeded()
     }
   }
 

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -41,9 +41,11 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
         }
       }
       
+      allDayView.reloadData()
+      allDayView.scrollToBottom()
+      
       recalculateEventLayout()
       prepareEventViews()
-      layoutAllDayEvents()
       setNeedsLayout()
     }
     get {
@@ -59,19 +61,20 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
 
   lazy var nowLine: CurrentTimeIndicator = CurrentTimeIndicator()
   
+  private var allDayViewTopConstraint: NSLayoutConstraint?
   lazy var allDayView: AllDayView = {
     let allDayView = AllDayView(frame: CGRect.zero)
     allDayView.dataSource = self
     
+    addSubview(allDayView)
+
     allDayView.translatesAutoresizingMaskIntoConstraints = false
-    insertSubview(allDayView, aboveSubview: nowLine)
-    
     self.allDayViewTopConstraint = allDayView.topAnchor.constraint(equalTo: topAnchor, constant: 0)
     self.allDayViewTopConstraint!.isActive = true
-    
-    allDayView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0).isActive = true
-    allDayView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0).isActive = true
-    
+
+    allDayView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 0).isActive = true
+    allDayView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0).isActive = true
+
     return allDayView
   }()
 
@@ -223,6 +226,7 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
     recalculateEventLayout()
     layoutEvents()
     layoutNowLine()
+    layoutAllDayEvents()
   }
 
   func layoutNowLine() {
@@ -230,7 +234,6 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
       nowLine.alpha = 0
     } else {
       bringSubview(toFront: nowLine)
-      bringSubview(toFront: allDayView)
       nowLine.alpha = 1
       let size = CGSize(width: bounds.size.width, height: 20)
       let rect = CGRect(origin: CGPoint.zero, size: size)
@@ -251,10 +254,8 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
     }
   }
   
-  private var allDayViewTopConstraint: NSLayoutConstraint?
   func layoutAllDayEvents() {
-    allDayView.reloadData()
-    allDayView.scrollToBottom()
+    bringSubview(toFront: allDayView)
   }
   
   func updateAllDayView(by yValue: CGFloat) {

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -48,8 +48,6 @@ public class TimelineView: UIView, ReusableView {
       recalculateEventLayout()
       prepareEventViews()
       allDayView.events = allDayLayoutAttributes.map { $0.descriptor }
-      
-      //TODO: resize to height of zero if count is zero vs using hidden
       allDayView.isHidden = allDayLayoutAttributes.count == 0
       allDayView.scrollToBottom()
       
@@ -76,13 +74,17 @@ public class TimelineView: UIView, ReusableView {
     addSubview(allDayView)
 
     self.allDayViewTopConstraint = allDayView.topAnchor.constraint(equalTo: topAnchor, constant: 0)
-    self.allDayViewTopConstraint!.isActive = true
+    self.allDayViewTopConstraint?.isActive = true
 
     allDayView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 0).isActive = true
     allDayView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0).isActive = true
 
     return allDayView
   }()
+  
+  var allDayViewHeight: CGFloat {
+    return allDayView.bounds.height
+  }
 
   var style = TimelineStyle()
 
@@ -261,6 +263,8 @@ public class TimelineView: UIView, ReusableView {
   }
   
   func layoutAllDayEvents() {
+    
+    //add day view needs to be in front of the nowLine
     bringSubview(toFront: allDayView)
   }
   

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -6,7 +6,7 @@ public protocol TimelineViewDelegate: class {
   func timelineView(_ timelineView: TimelineView, didLongPressAt hour: Int)
 }
 
-public class TimelineView: UIView, ReusableView {
+public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
 
   public weak var delegate: TimelineViewDelegate?
 
@@ -57,6 +57,15 @@ public class TimelineView: UIView, ReusableView {
   }
 
   lazy var nowLine: CurrentTimeIndicator = CurrentTimeIndicator()
+  
+  lazy var allDayView: AllDayView = {
+    let allDayView = AllDayView(frame: CGRect())
+    allDayView.dataSource = self
+    
+    addSubview(allDayView)
+    
+    return allDayView
+  }()
 
   var style = TimelineStyle()
 
@@ -204,6 +213,7 @@ public class TimelineView: UIView, ReusableView {
   override public func layoutSubviews() {
     super.layoutSubviews()
     recalculateEventLayout()
+    layoutAllDayEvents()
     layoutEvents()
     layoutNowLine()
   }
@@ -231,6 +241,10 @@ public class TimelineView: UIView, ReusableView {
       eventView.frame = attributes.frame
       eventView.updateWithDescriptor(event: descriptor)
     }
+  }
+  
+  func layoutAllDayEvents() {
+    
   }
 
   func recalculateEventLayout() {
@@ -303,6 +317,16 @@ public class TimelineView: UIView, ReusableView {
     pool.enqueue(views: eventViews)
     eventViews.removeAll()
     setNeedsDisplay()
+  }
+  
+  public func numberOfAllDayEvents(in allDayView: AllDayView) -> Int {
+    return allDayLayoutAttributes.count
+  }
+  
+  public func allDayView(_ allDayView: AllDayView, eventDescriptorFor index: Int) -> EventDescriptor {
+    let eventDescriptor = allDayLayoutAttributes[index].descriptor
+    
+    return eventDescriptor
   }
 
   // MARK: - Helpers

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -63,9 +63,9 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
     let allDayView = AllDayView(frame: CGRect.zero)
     allDayView.dataSource = self
     
+    allDayView.translatesAutoresizingMaskIntoConstraints = false
     insertSubview(allDayView, aboveSubview: nowLine)
     
-    allDayView.translatesAutoresizingMaskIntoConstraints = false
     self.allDayViewTopConstraint = allDayView.topAnchor.constraint(equalTo: topAnchor, constant: 0)
     self.allDayViewTopConstraint!.isActive = true
     
@@ -131,7 +131,7 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
     layer.contentsScale = 1
     contentMode = .redraw
     backgroundColor = .white
-    addSubview(nowLine)
+    insertSubview(nowLine, belowSubview: allDayView)
     
     // Add long press gesture recognizer
     addGestureRecognizer(longPressGestureRecognizer)
@@ -230,6 +230,7 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
       nowLine.alpha = 0
     } else {
       bringSubview(toFront: nowLine)
+      bringSubview(toFront: allDayView)
       nowLine.alpha = 1
       let size = CGSize(width: bounds.size.width, height: 20)
       let rect = CGRect(origin: CGPoint.zero, size: size)

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -10,7 +10,11 @@ public class TimelineView: UIView, ReusableView {
 
   public weak var delegate: TimelineViewDelegate?
 
-  public weak var eventViewDelegate: EventViewDelegate?
+  public weak var eventViewDelegate: EventViewDelegate? {
+    didSet {
+      self.allDayView.eventViewDelegate = eventViewDelegate
+    }
+  }
 
   public var date = Date() {
     didSet {

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -59,13 +59,23 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
   lazy var nowLine: CurrentTimeIndicator = CurrentTimeIndicator()
   
   lazy var allDayView: AllDayView = {
-    let allDayView = AllDayView(frame: CGRect())
+    let allDayView = AllDayView(frame: CGRect(x: 0, y: 0, width: bounds.width, height: 64.0))
     allDayView.dataSource = self
-    
-    addSubview(allDayView)
     
     return allDayView
   }()
+  
+  func layoutAllDayEvents() {
+    addSubview(allDayView)
+    allDayView.translatesAutoresizingMaskIntoConstraints = false
+    allDayView.topAnchor.constraint(equalTo: topAnchor, constant: 0).isActive = true
+    allDayView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0).isActive = true
+    allDayView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0).isActive = true
+    allDayView.heightAnchor.constraint(equalToConstant: 64).isActive = true
+    layoutIfNeeded()
+    
+    allDayView.reloadData()
+  }
 
   var style = TimelineStyle()
 
@@ -241,10 +251,6 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
       eventView.frame = attributes.frame
       eventView.updateWithDescriptor(event: descriptor)
     }
-  }
-  
-  func layoutAllDayEvents() {
-    
   }
 
   func recalculateEventLayout() {

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -59,7 +59,7 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
   lazy var nowLine: CurrentTimeIndicator = CurrentTimeIndicator()
   
   lazy var allDayView: AllDayView = {
-    let allDayView = AllDayView(frame: CGRect(x: 0, y: 0, width: bounds.width, height: 64.0))
+    let allDayView = AllDayView(frame: CGRect.zero)
     allDayView.dataSource = self
     
     return allDayView
@@ -71,9 +71,11 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
     allDayView.topAnchor.constraint(equalTo: topAnchor, constant: 0).isActive = true
     allDayView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0).isActive = true
     allDayView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0).isActive = true
-    layoutIfNeeded()
     
     allDayView.reloadData()
+    layoutIfNeeded()
+    
+    allDayView.scrollToBottom()
   }
 
   var style = TimelineStyle()
@@ -325,7 +327,12 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
   }
   
   public func numberOfAllDayEvents(in allDayView: AllDayView) -> Int {
-    return allDayLayoutAttributes.count
+    let count = allDayLayoutAttributes.count
+    
+    //TODO: resize to height of zero vs using hidden
+    allDayView.isHidden = count == 0
+    
+    return count
   }
   
   public func allDayView(_ allDayView: AllDayView, eventDescriptorFor index: Int) -> EventDescriptor {

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -6,7 +6,7 @@ public protocol TimelineViewDelegate: class {
   func timelineView(_ timelineView: TimelineView, didLongPressAt hour: Int)
 }
 
-public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
+public class TimelineView: UIView, ReusableView {
 
   public weak var delegate: TimelineViewDelegate?
 
@@ -43,10 +43,9 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
       
       recalculateEventLayout()
       prepareEventViews()
-      setNeedsLayout()
-      
-      allDayView.reloadData()
+      allDayView.events = allDayLayoutAttributes.map { $0.descriptor }
       allDayView.scrollToBottom()
+      setNeedsLayout()
     }
     get {
       return allDayLayoutAttributes + regularLayoutAttributes
@@ -64,11 +63,10 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
   private var allDayViewTopConstraint: NSLayoutConstraint?
   lazy var allDayView: AllDayView = {
     let allDayView = AllDayView(frame: CGRect.zero)
-    allDayView.dataSource = self
     
+    allDayView.translatesAutoresizingMaskIntoConstraints = false
     addSubview(allDayView)
 
-    allDayView.translatesAutoresizingMaskIntoConstraints = false
     self.allDayViewTopConstraint = allDayView.topAnchor.constraint(equalTo: topAnchor, constant: 0)
     self.allDayViewTopConstraint!.isActive = true
 
@@ -335,21 +333,6 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
     pool.enqueue(views: eventViews)
     eventViews.removeAll()
     setNeedsDisplay()
-  }
-  
-  public func numberOfAllDayEvents(in allDayView: AllDayView) -> Int {
-    let count = allDayLayoutAttributes.count
-    
-    //TODO: resize to height of zero vs using hidden
-    allDayView.isHidden = count == 0
-    
-    return count
-  }
-  
-  public func allDayView(_ allDayView: AllDayView, eventDescriptorFor index: Int) -> EventDescriptor {
-    let eventDescriptor = allDayLayoutAttributes[index].descriptor
-    
-    return eventDescriptor
   }
 
   // MARK: - Helpers

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -71,7 +71,6 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
     allDayView.topAnchor.constraint(equalTo: topAnchor, constant: 0).isActive = true
     allDayView.leftAnchor.constraint(equalTo: leftAnchor, constant: 0).isActive = true
     allDayView.rightAnchor.constraint(equalTo: rightAnchor, constant: 0).isActive = true
-    allDayView.heightAnchor.constraint(equalToConstant: 64).isActive = true
     layoutIfNeeded()
     
     allDayView.reloadData()

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -260,7 +260,13 @@ public class TimelineView: UIView, ReusableView {
     bringSubview(toFront: allDayView)
   }
   
-  func updateAllDayView(by yValue: CGFloat) {
+  /**
+   This will keep the allDayView as a staionary view in its superview
+   
+   - parameter yValue: since the superview is a scrollView, `yValue` is the
+   `contentOffset.y` of the scroll view
+   */
+  func offsetAllDayView(by yValue: CGFloat) {
     if let topConstraint = self.allDayViewTopConstraint {
       topConstraint.constant = yValue
       layoutIfNeeded()

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -41,12 +41,12 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
         }
       }
       
-      allDayView.reloadData()
-      allDayView.scrollToBottom()
-      
       recalculateEventLayout()
       prepareEventViews()
       setNeedsLayout()
+      
+      allDayView.reloadData()
+      allDayView.scrollToBottom()
     }
     get {
       return allDayLayoutAttributes + regularLayoutAttributes
@@ -134,7 +134,7 @@ public class TimelineView: UIView, ReusableView, AllDayViewDataSource {
     layer.contentsScale = 1
     contentMode = .redraw
     backgroundColor = .white
-    insertSubview(nowLine, belowSubview: allDayView)
+    addSubview(nowLine)
     
     // Add long press gesture recognizer
     addGestureRecognizer(longPressGestureRecognizer)

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -44,7 +44,11 @@ public class TimelineView: UIView, ReusableView {
       recalculateEventLayout()
       prepareEventViews()
       allDayView.events = allDayLayoutAttributes.map { $0.descriptor }
+      
+      //TODO: resize to height of zero if count is zero vs using hidden
+      allDayView.isHidden = allDayLayoutAttributes.count == 0
       allDayView.scrollToBottom()
+      
       setNeedsLayout()
     }
     get {


### PR DESCRIPTION
separate all day events from the non-all day events 👍 

closes #18 

### What's New
- `AllDayView` layouts `EventView`s in a `UIScrollView` similar to Apple's Calendar app


### Changes
- Added `allDay: Bool` to `EventDescriptor` and `Event`

### What to review
- [ ] filtering method (separation of all day event)
- [ ] Max height of `AllDayView`


### What's left
- [ ] Performance of updating the **stationary view**
- [x] `all-day` label in the `AllDayView`
- [x] Tapping an event needs to invoke the `delegate`