### PR TITLE
Fixed scrollToFirstEvent bug

### DIFF
--- a/Source/Timeline/TimelineContainer.swift
+++ b/Source/Timeline/TimelineContainer.swift
@@ -35,8 +35,10 @@ public class TimelineContainer: UIScrollView, ReusableView {
   }
   
   public func scrollToFirstEvent() {
+    let allDayViewHeight = timeline.allDayViewHeight
+    let padding = allDayViewHeight + 8
     if let yToScroll = timeline.firstEventYPosition {
-      setTimelineOffset(CGPoint(x: contentOffset.x, y: yToScroll - 15), animated: true)
+      setTimelineOffset(CGPoint(x: contentOffset.x, y: yToScroll - padding), animated: true)
     }
   }
   


### PR DESCRIPTION
When `dayView.autoScrollToFirstEvent` was set to `true`, and the dayView also had allDay events, scrolling to the first event would mean hiding part of that event.

Before:
<img width="478" alt="screen shot 2018-09-10 at 11 32 03 pm" src="https://user-images.githubusercontent.com/10365982/45336569-235c5700-b552-11e8-9be9-73de9ea14f06.png">

After:
<img width="478" alt="screen shot 2018-09-10 at 11 32 27 pm" src="https://user-images.githubusercontent.com/10365982/45336576-28210b00-b552-11e8-9e20-4937ac2530aa.png">
