### PR TITLE
Added event info to event protocol

### DIFF
--- a/Source/Timeline/Event.swift
+++ b/Source/Timeline/Event.swift
@@ -18,5 +18,6 @@ open class Event: EventDescriptor {
   public var textColor = UIColor.black
   public var font = UIFont.boldSystemFont(ofSize: 12)
   public var userInfo: Any?
+  public var eventInfo: Any? 
   public init() {}
 }

--- a/Source/Timeline/Event.swift
+++ b/Source/Timeline/Event.swift
@@ -18,6 +18,6 @@ open class Event: EventDescriptor {
   public var textColor = UIColor.black
   public var font = UIFont.boldSystemFont(ofSize: 12)
   public var userInfo: Any?
-  public var eventInfo: Any? 
+  public var eventInfo: Any
   public init() {}
 }

--- a/Source/Timeline/Event.swift
+++ b/Source/Timeline/Event.swift
@@ -18,6 +18,6 @@ open class Event: EventDescriptor {
   public var textColor = UIColor.black
   public var font = UIFont.boldSystemFont(ofSize: 12)
   public var userInfo: Any?
-  public var eventInfo: Any
+  public var eventInfo: Any?
   public init() {}
 }

--- a/Source/Timeline/EventDescriptor.swift
+++ b/Source/Timeline/EventDescriptor.swift
@@ -10,5 +10,5 @@ public protocol EventDescriptor {
   var color: UIColor {get}
   var textColor: UIColor {get}
   var backgroundColor: UIColor {get}
-  var eventInfo: Any {get}
+  var eventInfo: Any? {get}
 }

--- a/Source/Timeline/EventDescriptor.swift
+++ b/Source/Timeline/EventDescriptor.swift
@@ -10,4 +10,5 @@ public protocol EventDescriptor {
   var color: UIColor {get}
   var textColor: UIColor {get}
   var backgroundColor: UIColor {get}
+  var eventInfo: Any {get}
 }


### PR DESCRIPTION
I've been using this calendarkit library for a while, and I noticed that there was nothing allowing users to actually store info about the event inside of the event descriptor protocol, so I added it. 

This change could be useful for being able to get information about the event when the user calls dayViewDidSelectEventView, for example. 