### PR TITLE
Ability have gaps between events

### DIFF
--- a/Source/CalendarStyle.swift
+++ b/Source/CalendarStyle.swift
@@ -108,6 +108,7 @@ public class TimelineStyle: NSCopying {
   public var verticalDiff: CGFloat = 45
   public var verticalInset: CGFloat = 10
   public var leftInset: CGFloat = 53
+  public var eventGap: CGFloat = 0
   public init() {}
   public func copy(with zone: NSZone? = nil) -> Any {
     let copy = TimelineStyle()
@@ -121,6 +122,7 @@ public class TimelineStyle: NSCopying {
     copy.splitMinuteInterval = splitMinuteInterval
     copy.verticalDiff = verticalDiff
     copy.verticalInset = verticalInset
+    copy.eventGap = eventGap
     return copy
   }
 }

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -254,6 +254,10 @@ public class TimelineView: UIView, ReusableView {
       let descriptor = attributes.descriptor
       let eventView = eventViews[idx]
       eventView.frame = attributes.frame
+      eventView.frame = CGRect(x: attributes.frame.minX,
+                               y: attributes.frame.minY,
+                               width: attributes.frame.width - style.eventGap,
+                               height: attributes.frame.height - style.eventGap)
       eventView.updateWithDescriptor(event: descriptor)
     }
   }


### PR DESCRIPTION
Allows developers to adjust the space between appointments that are right beside each other.

eventGap = 0
![screen shot 2019-01-08 at 5 10 25 pm](https://user-images.githubusercontent.com/14794275/50864708-7f03e900-1368-11e9-980c-f452047694c4.png)

eventGap = 2.0
![screen shot 2019-01-08 at 5 11 40 pm](https://user-images.githubusercontent.com/14794275/50864711-81fed980-1368-11e9-9463-30664690ec8b.png)
