### PR TITLE
Fix member access to allow friendly DayView customization without forks

### DIFF
--- a/Source/Header/DayHeaderView.swift
+++ b/Source/Header/DayHeaderView.swift
@@ -9,7 +9,7 @@ public class DayHeaderView: UIView, DaySelectorDelegate, DayViewStateUpdating, U
   var style = DayHeaderStyle()
   var currentSizeClass = UIUserInterfaceSizeClass.compact
 
-  weak var state: DayViewState? {
+  public weak var state: DayViewState? {
     willSet(newValue) {
       state?.unsubscribe(client: self)
     }
@@ -31,7 +31,7 @@ public class DayHeaderView: UIView, DaySelectorDelegate, DayViewStateUpdating, U
                                                        options: nil)
   let swipeLabelView: SwipeLabelView
 
-  init(calendar: Calendar) {
+  public init(calendar: Calendar) {
     self.calendar = calendar
     let symbols = DaySymbolsView(calendar: calendar)
     let swipeLabel = SwipeLabelView(calendar: calendar)

--- a/Source/Timeline/TimelinePagerView.swift
+++ b/Source/Timeline/TimelinePagerView.swift
@@ -51,7 +51,7 @@ public class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScrollVie
     return contains
   }
 
-  weak var state: DayViewState? {
+  public weak var state: DayViewState? {
     willSet(newValue) {
       state?.unsubscribe(client: self)
     }
@@ -60,7 +60,7 @@ public class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScrollVie
     }
   }
 
-  init(calendar: Calendar) {
+  public init(calendar: Calendar) {
     self.calendar = calendar
     super.init(frame: .zero)
     configure()
@@ -172,7 +172,7 @@ public class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScrollVie
     timeline.layoutAttributes = validEvents.map(EventLayoutAttributes.init)
   }
 
-  func scrollToFirstEventIfNeeded() {
+  public func scrollToFirstEventIfNeeded() {
     if autoScrollToFirstEvent {
       if let controller = pagingViewController.viewControllers?.first as? TimelineContainerController {
         controller.container.scrollToFirstEvent()


### PR DESCRIPTION
I'd like to customize DayView but when I copy the source code some members of DayHeader and TimelinePagerView are not public.

This PR fixes those member levels.