### PR TITLE
add SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.1
+  // The swift-tools-version declares the minimum version of Swift required to build this package.
+ import PackageDescription
+
+   let package = Package(
+     name: "CalendarKit",
+     platforms: [
+         .iOS(.v9)
+     ],
+     products: [
+         // Products define the executables and libraries produced by a package, and make them visible to other packages.
+         .library(
+             name: "CalendarKit",
+             targets: ["CalendarKit"]),
+     ],
+     dependencies: [
+         // Dependencies declare other packages that this package depends on.
+         // .package(url: /* package url */, from: "1.0.0"),
+         .package(url: "https://github.com/tomaculum/Neon.git", .branch("master")),
+         .package(url: "https://github.com/maniramezan/DateTools.git", .branch("mani_swiftpm"))
+     ],
+     targets: [
+         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+         .target(name: "CalendarKit", dependencies: ["Neon", "DateToolsSwift"], path: "Source")
+     ],
+     swiftLanguageVersions: [.version("5.1")]
+ )

--- a/README.md
+++ b/README.md
@@ -19,11 +19,22 @@ pod try CalendarKit
 
 ## Installation
 
-**CalendarKit** is available through [CocoaPods](http://cocoapods.org). To install it, add the following line to your Podfile:
+
+**CalendarKit** is available through [CocoaPods](http://cocoapods.org) or Swift Package Manager (Xcode11+). 
+
+### CocoaPods
+
+To install it, add the following line to your Podfile:
 
 ```ruby
 pod 'CalendarKit'
 ```
+
+### Swift Package Manager (Xcode 11+)
+
+Open your project, select `File > Swift Packages > Add Package Depedency` and copy the [repository URL](https://github.com/richardtop/CalendarKit.git) into the search bar.
+
+A more detailed guide can be found here: [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app)
 
 ## Usage
 Subclass DayViewController and implement `DayViewDataSource` protocol to show events.


### PR DESCRIPTION
This isn't a beautiful way of doing this but it works. 

There is a open pull request for adding SPM to DateToolsSwift: https://github.com/MatthewYork/DateTools/pull/291

I took the branch and added it with its full url and `mani_siwftpm` as branch. After their pull request got merged, this should be changed to the typical `from:` notation with a release number.

As for the Neon dependency, I did fork this and added the [Package.swift file](https://github.com/mamaral/Neon/compare/master...tomaculum:master) myself. Since the project did not receive an update in a very long time, I guess this does not cause any issues.
I would suggest that @richardtop should fork this, add this one file and we replace the url with his repo.

related issue: #210