### PR TITLE
Fix Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@
      dependencies: [
          // Dependencies declare other packages that this package depends on.
          // .package(url: /* package url */, from: "1.0.0"),
-         .package(url: "https://github.com/maniramezan/DateTools.git", .branch("mani_swiftpm"))
+         .package(url: "https://github.com/maniramezan/DateTools.git", .branch("mani_swiftpm_5_3"))
      ],
      targets: [
          // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
The branch mani_swiftpm was renamed to mani_swiftpm_5_3 https://github.com/maniramezan/DateTools/tree/mani_swiftpm_5_3