### PR TITLE
If two events' start and end times are exactly equal to each other AND event gap is set, do not consider them as overlapping.

### DIFF
--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -414,8 +414,8 @@ public final class TimelineView: UIView {
         }
       } else {
         let lastEvent = overlappingEvents.last!
-        if longestEvent.descriptor.datePeriod.overlaps(event.descriptor.datePeriod) ||
-          lastEvent.descriptor.datePeriod.overlaps(event.descriptor.datePeriod) {
+        if (longestEvent.descriptor.datePeriod.overlaps(event.descriptor.datePeriod) && (longestEvent.descriptor.endDate != event.descriptor.startDate || style.eventGap <= 0.0)) ||
+          (lastEvent.descriptor.datePeriod.overlaps(event.descriptor.datePeriod) && (lastEvent.descriptor.endDate != event.descriptor.startDate || style.eventGap <= 0.0)) {
           overlappingEvents.append(event)
           continue
         }


### PR DESCRIPTION
**This effect is applied only if event gap is greater than 0.**
This is the behavior in iOS calendar. The effect of the changes are shown below, with an event gap of value 2.0:

Before changes:
<img width="461" alt="Before" src="https://user-images.githubusercontent.com/20627327/99635783-8b245b80-2a53-11eb-8bc0-800c4633c08a.png">

After changes:
<img width="461" alt="After" src="https://user-images.githubusercontent.com/20627327/99635812-94adc380-2a53-11eb-868b-a12602b3ddcd.png">