### PR TITLE
Fix localization issue

### DIFF
--- a/Source/Header/SwipeLabelView.swift
+++ b/Source/Header/SwipeLabelView.swift
@@ -109,6 +109,7 @@ public final class SwipeLabelView: UIView, DayViewStateUpdating {
     formatter.dateStyle = .full
     formatter.timeStyle = .none
     formatter.timeZone = timezone
+    formatter.locale = Locale.init(identifier: Locale.preferredLanguages[0])
     return formatter.string(from: date)
   }
 }


### PR DESCRIPTION
Now the labels at the top are localized depending on the preferred language in the settings. Previously, the system language had no effect on this.