### PR TITLE
RTL support

### DIFF
--- a/Source/CalendarStyle.swift
+++ b/Source/CalendarStyle.swift
@@ -70,7 +70,7 @@ public struct TimelineStyle {
   public var splitMinuteInterval: Int = 15
   public var verticalDiff: CGFloat = 50
   public var verticalInset: CGFloat = 10
-  public var leftInset: CGFloat = 53
+  public var leadingInset: CGFloat = 53
   public var eventGap: CGFloat = 0
   public init() {}
 }

--- a/Source/Header/DayHeaderView.swift
+++ b/Source/Header/DayHeaderView.swift
@@ -55,8 +55,8 @@ public final class DayHeaderView: UIView, DaySelectorDelegate, DayViewStateUpdat
     vc.selectedDate = selectedDate
     currentWeekdayIndex = vc.selectedIndex
     
-    let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
-    let direction: UIPageViewController.NavigationDirection = ltr ? .forward : .reverse
+    let leftToRight = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .leftToRight
+    let direction: UIPageViewController.NavigationDirection = leftToRight ? .forward : .reverse
     
     pagingViewController.setViewControllers([vc], direction: direction, animated: false, completion: nil)
     pagingViewController.dataSource = self
@@ -129,21 +129,21 @@ public final class DayHeaderView: UIView, DaySelectorDelegate, DayViewStateUpdat
     let newStartDate = beginningOfWeek(newDate)
 
     let new = makeSelectorController(startDate: newStartDate)
+    
+    let leftToRight = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .leftToRight
 
     if daysFrom < 0 {
       currentWeekdayIndex = abs(daysInWeek + daysFrom % daysInWeek) % daysInWeek
       new.selectedIndex = currentWeekdayIndex
-        
-      let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
-      let direction: UIPageViewController.NavigationDirection = ltr ? .reverse : .forward
+      
+      let direction: UIPageViewController.NavigationDirection = leftToRight ? .reverse : .forward
         
       pagingViewController.setViewControllers([new], direction: direction, animated: true, completion: nil)
     } else if daysFrom > daysInWeek - 1 {
       currentWeekdayIndex = daysFrom % daysInWeek
       new.selectedIndex = currentWeekdayIndex
-        
-      let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
-      let direction: UIPageViewController.NavigationDirection = ltr ? .forward : .reverse
+      
+      let direction: UIPageViewController.NavigationDirection = leftToRight ? .forward : .reverse
         
       pagingViewController.setViewControllers([new], direction: direction, animated: true, completion: nil)
     } else {

--- a/Source/Header/DayHeaderView.swift
+++ b/Source/Header/DayHeaderView.swift
@@ -54,7 +54,11 @@ public final class DayHeaderView: UIView, DaySelectorDelegate, DayViewStateUpdat
     let vc = makeSelectorController(startDate: beginningOfWeek(selectedDate))
     vc.selectedDate = selectedDate
     currentWeekdayIndex = vc.selectedIndex
-    pagingViewController.setViewControllers([vc], direction: .forward, animated: false, completion: nil)
+    
+    let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
+    let direction: UIPageViewController.NavigationDirection = ltr ? .forward : .reverse
+    
+    pagingViewController.setViewControllers([vc], direction: direction, animated: false, completion: nil)
     pagingViewController.dataSource = self
     pagingViewController.delegate = self
     addSubview(pagingViewController.view!)
@@ -129,11 +133,19 @@ public final class DayHeaderView: UIView, DaySelectorDelegate, DayViewStateUpdat
     if daysFrom < 0 {
       currentWeekdayIndex = abs(daysInWeek + daysFrom % daysInWeek) % daysInWeek
       new.selectedIndex = currentWeekdayIndex
-      pagingViewController.setViewControllers([new], direction: .reverse, animated: true, completion: nil)
+        
+      let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
+      let direction: UIPageViewController.NavigationDirection = ltr ? .reverse : .forward
+        
+      pagingViewController.setViewControllers([new], direction: direction, animated: true, completion: nil)
     } else if daysFrom > daysInWeek - 1 {
       currentWeekdayIndex = daysFrom % daysInWeek
       new.selectedIndex = currentWeekdayIndex
-      pagingViewController.setViewControllers([new], direction: .forward, animated: true, completion: nil)
+        
+      let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
+      let direction: UIPageViewController.NavigationDirection = ltr ? .forward : .reverse
+        
+      pagingViewController.setViewControllers([new], direction: direction, animated: true, completion: nil)
     } else {
       currentWeekdayIndex = daysFrom
       centerView.selectedDate = newDate

--- a/Source/Header/DayHeaderView.swift
+++ b/Source/Header/DayHeaderView.swift
@@ -185,7 +185,7 @@ public final class DayHeaderView: UIView, DaySelectorDelegate, DayViewStateUpdat
     (previousViewControllers as? [DaySelectorController])?.forEach{$0.selectedIndex = -1}
   }
 
-  public func pageViewController(_ pageViewController: UIPageViewController, willTransitionTo pendingViewControllers: [UIViewController]) {
+  public func pageViewController(_ pageViewController: UIPageViewController, willlTransitionTo pendingViewControllers: [UIViewController]) {
     (pendingViewControllers as? [DaySelectorController])?.forEach{$0.updateStyle(style.daySelector)}
   }
 }

--- a/Source/Header/DayHeaderView.swift
+++ b/Source/Header/DayHeaderView.swift
@@ -185,7 +185,7 @@ public final class DayHeaderView: UIView, DaySelectorDelegate, DayViewStateUpdat
     (previousViewControllers as? [DaySelectorController])?.forEach{$0.selectedIndex = -1}
   }
 
-  public func pageViewController(_ pageViewController: UIPageViewController, willlTransitionTo pendingViewControllers: [UIViewController]) {
+    public func pageViewController(_ pageViewController: UIPageViewController, willTransitionTo pendingViewControllers: [UIViewController]) {
     (pendingViewControllers as? [DaySelectorController])?.forEach{$0.updateStyle(style.daySelector)}
   }
 }

--- a/Source/Header/DaySelector/DaySelector.swift
+++ b/Source/Header/DaySelector/DaySelector.swift
@@ -131,11 +131,18 @@ public final class DaySelector: UIView {
     let minX = per / 2
 
     for (i, item) in items.enumerated() {
-      let origin = CGPoint(x: minX + (size.width + per) * CGFloat(i),
+        
+        var x = minX + (size.width + per) * CGFloat(i)
+        
+        if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+            x = parentWidth - x - size.width
+        }
+        
+        let origin = CGPoint(x: x,
                            y: 0)
-      let frame = CGRect(origin: origin,
+        let frame = CGRect(origin: origin,
                          size: size)
-      item.frame = frame
+        item.frame = frame
     }
   }
 

--- a/Source/Header/DaySelector/DaySelector.swift
+++ b/Source/Header/DaySelector/DaySelector.swift
@@ -134,7 +134,8 @@ public final class DaySelector: UIView {
         
         var x = minX + (size.width + per) * CGFloat(i)
         
-        if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+        let rightToLeft = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
+        if rightToLeft {
             x = parentWidth - x - size.width
         }
         

--- a/Source/Header/DaySymbolsView.swift
+++ b/Source/Header/DaySymbolsView.swift
@@ -45,8 +45,8 @@ public final class DaySymbolsView: UIView {
 
     weekDays.shift(calendar.firstWeekday - 1)
     
-    let rtl = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft
-    if rtl { weekDays.reverse() }
+    let rightToLeft = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
+    if rightToLeft { weekDays.reverse() }
 
     for (index, label) in labels.enumerated() {
       label.text = weekDays[index].0

--- a/Source/Header/DaySymbolsView.swift
+++ b/Source/Header/DaySymbolsView.swift
@@ -44,6 +44,9 @@ public final class DaySymbolsView: UIView {
     var weekDays = Array(zip(daySymbols, weekendMask))
 
     weekDays.shift(calendar.firstWeekday - 1)
+    
+    let rtl = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft
+    if rtl { weekDays.reverse() }
 
     for (index, label) in labels.enumerated() {
       label.text = weekDays[index].0

--- a/Source/Header/SwipeLabelView.swift
+++ b/Source/Header/SwipeLabelView.swift
@@ -110,8 +110,8 @@ public final class SwipeLabelView: UIView, DayViewStateUpdating {
     
     var direction: AnimationDirection = newDate > oldDate ? .Forward : .Backward
     
-    let rtl = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft
-    if rtl { direction.flip() }
+    let rightToLeft = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
+    if rightToLeft { direction.flip() }
     
     animate(direction)
   }

--- a/Source/Header/SwipeLabelView.swift
+++ b/Source/Header/SwipeLabelView.swift
@@ -4,6 +4,15 @@ public final class SwipeLabelView: UIView, DayViewStateUpdating {
   public enum AnimationDirection {
     case Forward
     case Backward
+    
+    mutating func flip() {
+        switch self {
+        case .Forward:
+            self = .Backward
+        case .Backward:
+            self = .Forward
+        }
+    }
   }
 
   public private(set) var calendar = Calendar.autoupdatingCurrent
@@ -98,7 +107,12 @@ public final class SwipeLabelView: UIView, DayViewStateUpdating {
     guard newDate != oldDate
       else { return }
     labels.last!.text = formattedDate(date: newDate)
-    let direction: AnimationDirection = newDate > oldDate ? .Forward : .Backward
+    
+    var direction: AnimationDirection = newDate > oldDate ? .Forward : .Backward
+    
+    let rtl = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft
+    if rtl { direction.flip() }
+    
     animate(direction)
   }
 

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -74,10 +74,13 @@ public final class AllDayView: UIView {
     
     let svLeftConstraint = scrollView.leadingAnchor.constraint(equalTo: textLabel.trailingAnchor, constant: 8)
     
-    self.addConstraints([
+    addConstraints([
         NSLayoutConstraint(item: textLabel, attribute: .leading, relatedBy: .equal, toItem: self, attribute: .leading, multiplier: 1, constant: 8),
+        
         NSLayoutConstraint(item: textLabel, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1, constant: 4),
+        
         NSLayoutConstraint(item: textLabel, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: allDayLabelWidth),
+        
         NSLayoutConstraint(item: textLabel, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 24)
     ])
     

--- a/Source/Timeline/AllDayView.swift
+++ b/Source/Timeline/AllDayView.swift
@@ -17,6 +17,7 @@ public final class AllDayView: UIView {
   
   private lazy var textLabel: UILabel = {
     let label = UILabel(frame: CGRect(x: 8.0, y: 4.0, width: allDayLabelWidth, height: 24.0))
+    label.translatesAutoresizingMaskIntoConstraints = false
     label.text = localizedString("all-day")
     label.setContentCompressionResistancePriority(.required, for: .horizontal)
     return label
@@ -72,6 +73,13 @@ public final class AllDayView: UIView {
     addSubview(textLabel)
     
     let svLeftConstraint = scrollView.leadingAnchor.constraint(equalTo: textLabel.trailingAnchor, constant: 8)
+    
+    self.addConstraints([
+        NSLayoutConstraint(item: textLabel, attribute: .leading, relatedBy: .equal, toItem: self, attribute: .leading, multiplier: 1, constant: 8),
+        NSLayoutConstraint(item: textLabel, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1, constant: 4),
+        NSLayoutConstraint(item: textLabel, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: allDayLabelWidth),
+        NSLayoutConstraint(item: textLabel, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 24)
+    ])
     
     /**
      Why is this constraint 999?

--- a/Source/Timeline/CurrentTimeIndicator.swift
+++ b/Source/Timeline/CurrentTimeIndicator.swift
@@ -104,7 +104,8 @@ import UIKit
     line.frame = {
         
         let x: CGFloat
-        if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+        let rightToLeft = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
+        if rightToLeft {
             x = 0
         } else {
             x = leadingInset - padding
@@ -116,7 +117,7 @@ import UIKit
     circle.frame = {
         
         let x: CGFloat
-        if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+        if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
             x = bounds.width - leadingInset - 10
         } else {
             x = leadingInset + 1

--- a/Source/Timeline/CurrentTimeIndicator.swift
+++ b/Source/Timeline/CurrentTimeIndicator.swift
@@ -2,7 +2,7 @@ import UIKit
 
 @objc public final class CurrentTimeIndicator: UIView {
   private let padding : CGFloat = 3
-  private let leftInset: CGFloat = 53
+  private let leadingInset: CGFloat = 53
 
   public var calendar: Calendar = Calendar.autoupdatingCurrent {
     didSet {
@@ -66,8 +66,8 @@ import UIKit
     //The width of the label is determined by leftInset and padding. 
     //The y position is determined by the line's middle.
     timeLabel.translatesAutoresizingMaskIntoConstraints = false
-    timeLabel.widthAnchor.constraint(equalToConstant: leftInset - (3 * padding)).isActive = true
-    timeLabel.rightAnchor.constraint(equalTo: line.leftAnchor, constant: -padding).isActive = true
+    timeLabel.widthAnchor.constraint(equalToConstant: leadingInset - (3 * padding)).isActive = true
+    timeLabel.trailingAnchor.constraint(equalTo: line.leadingAnchor, constant: -padding).isActive = true
     timeLabel.centerYAnchor.constraint(equalTo: line.centerYAnchor).isActive = true
     timeLabel.baselineAdjustment = .alignCenters
     
@@ -101,9 +101,29 @@ import UIKit
 
   override public func layoutSubviews() {
     super.layoutSubviews()
-    line.frame = CGRect(x: leftInset - padding, y: bounds.height / 2, width: bounds.width, height: 1)
+    line.frame = {
+        
+        let x: CGFloat
+        if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+            x = 0
+        } else {
+            x = leadingInset - padding
+        }
+        
+        return CGRect(x: x, y: bounds.height / 2, width: bounds.width - leadingInset, height: 1)
+    }()
 
-    circle.frame = CGRect(x: leftInset + 1, y: 0, width: 6, height: 6)
+    circle.frame = {
+        
+        let x: CGFloat
+        if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+            x = bounds.width - leadingInset - 10
+        } else {
+            x = leadingInset + 1
+        }
+        
+        return CGRect(x: x, y: 0, width: 6, height: 6)
+    }()
     circle.center.y = line.center.y
     circle.layer.cornerRadius = circle.bounds.height / 2
   }

--- a/Source/Timeline/EventView.swift
+++ b/Source/Timeline/EventView.swift
@@ -102,7 +102,7 @@ open class EventView: UIView {
     context.setStrokeColor(color.cgColor)
     context.setLineWidth(3)
     context.translateBy(x: 0, y: 0.5)
-    let x: CGFloat = self.frame.width - 3 // 3 is the line width
+    let x: CGFloat = frame.width - 3 // 3 is the line width
     let y: CGFloat = 0
     context.beginPath()
     context.move(to: CGPoint(x: x, y: y))
@@ -116,7 +116,7 @@ open class EventView: UIView {
   override open func layoutSubviews() {
     super.layoutSubviews()
     textView.frame = {
-        if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+        if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
             return CGRect(x: bounds.minX, y: bounds.minY, width: bounds.width - 3, height: bounds.height)
         } else {
             return CGRect(x: bounds.minX + 3, y: bounds.minY, width: bounds.width - 3, height: bounds.height)

--- a/Source/Timeline/EventView.swift
+++ b/Source/Timeline/EventView.swift
@@ -115,7 +115,13 @@ open class EventView: UIView {
 
   override open func layoutSubviews() {
     super.layoutSubviews()
-    textView.frame = CGRect(x: bounds.minX, y: bounds.minY, width: bounds.width - 3, height: bounds.height)
+    textView.frame = {
+        if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+            return CGRect(x: bounds.minX, y: bounds.minY, width: bounds.width - 3, height: bounds.height)
+        } else {
+            return CGRect(x: bounds.minX + 3, y: bounds.minY, width: bounds.width - 3, height: bounds.height)
+        }
+    }()
     if frame.minY < 0 {
       var textFrame = textView.frame;
       textFrame.origin.y = frame.minY * -1;

--- a/Source/Timeline/EventView.swift
+++ b/Source/Timeline/EventView.swift
@@ -100,9 +100,10 @@ open class EventView: UIView {
     context.interpolationQuality = .none
     context.saveGState()
     context.setStrokeColor(color.cgColor)
-    context.setLineWidth(3)
+    context.setLineWidth(1)
     context.translateBy(x: 0, y: 0.5)
-    let x: CGFloat = frame.width - 3 // 3 is the line width
+    let leftToRight = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .leftToRight
+    let x: CGFloat = leftToRight ? 0 : frame.width - 1  // 1 is the line width
     let y: CGFloat = 0
     context.beginPath()
     context.move(to: CGPoint(x: x, y: y))

--- a/Source/Timeline/EventView.swift
+++ b/Source/Timeline/EventView.swift
@@ -102,7 +102,7 @@ open class EventView: UIView {
     context.setStrokeColor(color.cgColor)
     context.setLineWidth(3)
     context.translateBy(x: 0, y: 0.5)
-    let x: CGFloat = 0
+    let x: CGFloat = self.frame.width - 3 // 3 is the line width
     let y: CGFloat = 0
     context.beginPath()
     context.move(to: CGPoint(x: x, y: y))
@@ -115,7 +115,7 @@ open class EventView: UIView {
 
   override open func layoutSubviews() {
     super.layoutSubviews()
-    textView.frame = bounds
+    textView.frame = CGRect(x: bounds.minX, y: bounds.minY, width: bounds.width - 3, height: bounds.height)
     if frame.minY < 0 {
       var textFrame = textView.frame;
       textFrame.origin.y = frame.minY * -1;

--- a/Source/Timeline/TimelinePagerView.swift
+++ b/Source/Timeline/TimelinePagerView.swift
@@ -408,11 +408,11 @@ public final class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScr
     delegate?.timelinePager(timelinePager: self, willMoveTo: newDate)
 
     func completionHandler(_ completion: Bool) {
-      DispatchQueue.main.async {
+      DispatchQueue.main.async { [self] in
         // Fix for the UIPageViewController issue: https://stackoverflow.com/questions/12939280/uipageviewcontroller-navigates-to-wrong-page-with-scroll-transition-style
         
         let leftToRight = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .leftToRight
-        let direction: UIPageViewController.NavigationDirection = ltr ? .reverse : .forward
+        let direction: UIPageViewController.NavigationDirection = leftToRight ? .reverse : .forward
         
         self.pagingViewController.setViewControllers([newController],
                                                       direction: direction,
@@ -427,14 +427,14 @@ public final class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScr
 
     if newDate < oldDate {
       let leftToRight = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .leftToRight
-      let direction: UIPageViewController.NavigationDirection = ltr ? .reverse : .forward
+      let direction: UIPageViewController.NavigationDirection = leftToRight ? .reverse : .forward
       pagingViewController.setViewControllers([newController],
                                               direction: direction,
                                               animated: true,
                                               completion: completionHandler(_:))
     } else if newDate > oldDate {
       let leftToRight = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .leftToRight
-      let direction: UIPageViewController.NavigationDirection = ltr ? .forward : .reverse
+      let direction: UIPageViewController.NavigationDirection = leftToRight ? .forward : .reverse
       pagingViewController.setViewControllers([newController],
                                               direction: direction,
                                               animated: true,

--- a/Source/Timeline/TimelinePagerView.swift
+++ b/Source/Timeline/TimelinePagerView.swift
@@ -411,7 +411,7 @@ public final class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScr
       DispatchQueue.main.async {
         // Fix for the UIPageViewController issue: https://stackoverflow.com/questions/12939280/uipageviewcontroller-navigates-to-wrong-page-with-scroll-transition-style
         
-        let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
+        let leftToRight = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .leftToRight
         let direction: UIPageViewController.NavigationDirection = ltr ? .reverse : .forward
         
         self.pagingViewController.setViewControllers([newController],
@@ -426,14 +426,14 @@ public final class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScr
     }
 
     if newDate < oldDate {
-      let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
+      let leftToRight = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .leftToRight
       let direction: UIPageViewController.NavigationDirection = ltr ? .reverse : .forward
       pagingViewController.setViewControllers([newController],
                                               direction: direction,
                                               animated: true,
                                               completion: completionHandler(_:))
     } else if newDate > oldDate {
-      let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
+      let leftToRight = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .leftToRight
       let direction: UIPageViewController.NavigationDirection = ltr ? .forward : .reverse
       pagingViewController.setViewControllers([newController],
                                               direction: direction,

--- a/Source/Timeline/TimelinePagerView.swift
+++ b/Source/Timeline/TimelinePagerView.swift
@@ -410,8 +410,12 @@ public final class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScr
     func completionHandler(_ completion: Bool) {
       DispatchQueue.main.async {
         // Fix for the UIPageViewController issue: https://stackoverflow.com/questions/12939280/uipageviewcontroller-navigates-to-wrong-page-with-scroll-transition-style
+        
+        let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
+        let direction: UIPageViewController.NavigationDirection = ltr ? .reverse : .forward
+        
         self.pagingViewController.setViewControllers([newController],
-                                                      direction: .reverse,
+                                                      direction: direction,
                                                       animated: false,
                                                       completion: nil)
               
@@ -422,13 +426,17 @@ public final class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScr
     }
 
     if newDate < oldDate {
+      let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
+      let direction: UIPageViewController.NavigationDirection = ltr ? .reverse : .forward
       pagingViewController.setViewControllers([newController],
-                                              direction: .reverse,
+                                              direction: direction,
                                               animated: true,
                                               completion: completionHandler(_:))
     } else if newDate > oldDate {
+      let ltr = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .leftToRight
+      let direction: UIPageViewController.NavigationDirection = ltr ? .forward : .reverse
       pagingViewController.setViewControllers([newController],
-                                              direction: .forward,
+                                              direction: direction,
                                               animated: true,
                                               completion: completionHandler(_:))
     }

--- a/Source/Timeline/TimelinePagerView.swift
+++ b/Source/Timeline/TimelinePagerView.swift
@@ -328,7 +328,8 @@ public final class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScr
         let ytd = yToDate(y: editedEventView.frame.origin.y,
                           timeline: timeline)
         let snapped = timeline.snappingBehavior.nearestDate(to: ytd)
-        let x = style.leadingInset
+        let leftToRight = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .leftToRight
+        let x = leftToRight ? style.leadingInset : 0
         
         var eventFrame = editedEventView.frame
         eventFrame.origin.x = x

--- a/Source/Timeline/TimelinePagerView.swift
+++ b/Source/Timeline/TimelinePagerView.swift
@@ -218,7 +218,10 @@ public final class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScr
       let yStart = timeline.dateToY(event.startDate) - offset
       let yEnd = timeline.dateToY(event.endDate) - offset
 
-      let newRect = CGRect(x: timeline.style.leadingInset,
+        
+      let rightToLeft = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
+      let x = rightToLeft ? 0 : timeline.style.leadingInset
+      let newRect = CGRect(x: x,
                            y: yStart,
                            width: timeline.calendarWidth,
                            height: yEnd - yStart)

--- a/Source/Timeline/TimelinePagerView.swift
+++ b/Source/Timeline/TimelinePagerView.swift
@@ -218,7 +218,7 @@ public final class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScr
       let yStart = timeline.dateToY(event.startDate) - offset
       let yEnd = timeline.dateToY(event.endDate) - offset
 
-      let newRect = CGRect(x: timeline.style.leftInset,
+      let newRect = CGRect(x: timeline.style.leadingInset,
                            y: yStart,
                            width: timeline.calendarWidth,
                            height: yEnd - yStart)
@@ -325,7 +325,7 @@ public final class TimelinePagerView: UIView, UIGestureRecognizerDelegate, UIScr
         let ytd = yToDate(y: editedEventView.frame.origin.y,
                           timeline: timeline)
         let snapped = timeline.snappingBehavior.nearestDate(to: ytd)
-        let x = style.leftInset
+        let x = style.leadingInset
         
         var eventFrame = editedEventView.frame
         eventFrame.origin.x = x

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -345,9 +345,19 @@ public final class TimelineView: UIView {
         }
     
         if hour == accentedHour {
-            let timeRect = CGRect(x: 2, y: hourFloat * style.verticalDiff + style.verticalInset - 7     + style.verticalDiff * (CGFloat(accentedMinute) / 60),
+            
+            var x: CGFloat
+            if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+                x = self.bounds.width - (style.leftInset + 7)
+            } else {
+                x = 2
+            }
+            
+            let timeRect = CGRect(x: x, y: hourFloat * style.verticalDiff + style.verticalInset - 7     + style.verticalDiff * (CGFloat(accentedMinute) / 60),
                                 width: style.leftInset - 8, height: fontSize + 2)
+            
             let timeString = NSString(string: ":\(accentedMinute)")
+            
             timeString.draw(in: timeRect, withAttributes: attributes)
         }
     }

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -293,6 +293,8 @@ public final class TimelineView: UIView {
     let offset = 0.5 - center
     
     for (hour, time) in times.enumerated() {
+        let rightToLeft = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft
+        
         let hourFloat = CGFloat(hour)
         let context = UIGraphicsGetCurrentContext()
         context!.interpolationQuality = .none
@@ -300,14 +302,14 @@ public final class TimelineView: UIView {
         context?.setStrokeColor(style.separatorColor.cgColor)
         context?.setLineWidth(hourLineHeight)
         let xStart: CGFloat = {
-            if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+            if rightToLeft {
                 return bounds.width - 53
             } else {
                 return 53
             }
         }()
         let xEnd: CGFloat = {
-            if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+            if rightToLeft {
                 return 0
             } else {
                 return bounds.width
@@ -325,7 +327,7 @@ public final class TimelineView: UIView {
         let fontSize = style.font.pointSize
         let timeRect: CGRect = {
             var x: CGFloat
-            if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+            if rightToLeft {
                 x = bounds.width - 53
             } else {
                 x = 2
@@ -347,8 +349,8 @@ public final class TimelineView: UIView {
         if hour == accentedHour {
             
             var x: CGFloat
-            if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
-                x = self.bounds.width - (style.leftInset + 7)
+            if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
+                x = bounds.width - (style.leftInset + 7)
             } else {
                 x = 2
             }
@@ -396,7 +398,7 @@ public final class TimelineView: UIView {
       eventView.frame = attributes.frame
         
       var x: CGFloat
-      if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+      if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
         x = bounds.width - attributes.frame.minX - attributes.frame.width
       } else {
         x = attributes.frame.minX

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -378,7 +378,7 @@ public final class TimelineView: UIView {
   }
 
   private func layoutEvents() {
-    if eventViews.isEmpty {return}
+    if eventViews.isEmpty { return }
     
     for (idx, attributes) in regularLayoutAttributes.enumerated() {
       let descriptor = attributes.descriptor
@@ -387,7 +387,7 @@ public final class TimelineView: UIView {
         
       var x: CGFloat
       if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
-          x = 0
+        x = bounds.width - attributes.frame.minX - attributes.frame.width
       } else {
         x = attributes.frame.minX
       }

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -293,39 +293,52 @@ public final class TimelineView: UIView {
     let offset = 0.5 - center
     
     for (hour, time) in times.enumerated() {
-      let hourFloat = CGFloat(hour)
-      let context = UIGraphicsGetCurrentContext()
-      context!.interpolationQuality = .none
-      context?.saveGState()
-      context?.setStrokeColor(style.separatorColor.cgColor)
-      context?.setLineWidth(hourLineHeight)
-      let x: CGFloat = 53
-      let y = style.verticalInset + hourFloat * style.verticalDiff + offset
-      context?.beginPath()
-      context?.move(to: CGPoint(x: x, y: y))
-      context?.addLine(to: CGPoint(x: (bounds).width, y: y))
-      context?.strokePath()
-      context?.restoreGState()
-
-      if hour == hourToRemoveIndex { continue }
-
-      let fontSize = style.font.pointSize
-      let timeRect = CGRect(x: 2, y: hourFloat * style.verticalDiff + style.verticalInset - 7,
-                            width: style.leftInset - 8, height: fontSize + 2)
-
-      let timeString = NSString(string: time)
-      timeString.draw(in: timeRect, withAttributes: attributes)
-
-      if accentedMinute == 0 {
-        continue
-      }
-
-      if hour == accentedHour {
-        let timeRect = CGRect(x: 2, y: hourFloat * style.verticalDiff + style.verticalInset - 7 + style.verticalDiff * (CGFloat(accentedMinute) / 60),
-                              width: style.leftInset - 8, height: fontSize + 2)
-        let timeString = NSString(string: ":\(accentedMinute)")
+        let hourFloat = CGFloat(hour)
+        let context = UIGraphicsGetCurrentContext()
+        context!.interpolationQuality = .none
+        context?.saveGState()
+        context?.setStrokeColor(style.separatorColor.cgColor)
+        context?.setLineWidth(hourLineHeight)
+        let xStart: CGFloat = {
+            if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+                return bounds.width - 53
+            } else {
+                return 53
+            }
+        }()
+        let xEnd: CGFloat = {
+            if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+                return 0
+            } else {
+                return bounds.width
+            }
+        }()
+        let y = style.verticalInset + hourFloat * style.verticalDiff + offset
+        context?.beginPath()
+        context?.move(to: CGPoint(x: xStart, y: y))
+        context?.addLine(to: CGPoint(x: xEnd, y: y))
+        context?.strokePath()
+        context?.restoreGState()
+    
+        if hour == hourToRemoveIndex { continue }
+    
+        let fontSize = style.font.pointSize
+        let timeRect = CGRect(x: 2, y: hourFloat * style.verticalDiff + style.verticalInset - 7,
+                                width: style.leftInset - 8, height: fontSize + 2)
+    
+        let timeString = NSString(string: time)
         timeString.draw(in: timeRect, withAttributes: attributes)
-      }
+    
+        if accentedMinute == 0 {
+            continue
+        }
+    
+        if hour == accentedHour {
+            let timeRect = CGRect(x: 2, y: hourFloat * style.verticalDiff + style.verticalInset - 7     + style.verticalDiff * (CGFloat(accentedMinute) / 60),
+                                width: style.leftInset - 8, height: fontSize + 2)
+            let timeString = NSString(string: ":\(accentedMinute)")
+            timeString.draw(in: timeRect, withAttributes: attributes)
+        }
     }
   }
   

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -323,8 +323,19 @@ public final class TimelineView: UIView {
         if hour == hourToRemoveIndex { continue }
     
         let fontSize = style.font.pointSize
-        let timeRect = CGRect(x: 2, y: hourFloat * style.verticalDiff + style.verticalInset - 7,
-                                width: style.leftInset - 8, height: fontSize + 2)
+        let timeRect: CGRect = {
+            var x: CGFloat
+            if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+                x = bounds.width - 53
+            } else {
+                x = 2
+            }
+            
+            return CGRect(x: x,
+                          y: hourFloat * style.verticalDiff + style.verticalInset - 7,
+                          width: style.leftInset - 8,
+                          height: fontSize + 2)
+        }()
     
         let timeString = NSString(string: time)
         timeString.draw(in: timeRect, withAttributes: attributes)

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -91,7 +91,7 @@ public final class TimelineView: UIView {
   }
 
   public var calendarWidth: CGFloat {
-    return bounds.width - style.leftInset
+    return bounds.width - style.leadingInset
   }
     
   public private(set) var is24hClock = true {
@@ -335,7 +335,7 @@ public final class TimelineView: UIView {
             
             return CGRect(x: x,
                           y: hourFloat * style.verticalDiff + style.verticalInset - 7,
-                          width: style.leftInset - 8,
+                          width: style.leadingInset - 8,
                           height: fontSize + 2)
         }()
     
@@ -350,13 +350,13 @@ public final class TimelineView: UIView {
             
             var x: CGFloat
             if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
-                x = bounds.width - (style.leftInset + 7)
+                x = bounds.width - (style.leadingInset + 7)
             } else {
                 x = 2
             }
             
             let timeRect = CGRect(x: x, y: hourFloat * style.verticalDiff + style.verticalInset - 7     + style.verticalDiff * (CGFloat(accentedMinute) / 60),
-                                width: style.leftInset - 8, height: fontSize + 2)
+                                width: style.leadingInset - 8, height: fontSize + 2)
             
             let timeString = NSString(string: ":\(accentedMinute)")
             
@@ -487,7 +487,7 @@ public final class TimelineView: UIView {
         let startY = dateToY(event.descriptor.datePeriod.lowerBound)
         let endY = dateToY(event.descriptor.datePeriod.upperBound)
         let floatIndex = CGFloat(index)
-        let x = style.leftInset + floatIndex / totalCount * calendarWidth
+        let x = style.leadingInset + floatIndex / totalCount * calendarWidth
         let equalWidth = calendarWidth / totalCount
         event.frame = CGRect(x: x, y: startY, width: equalWidth, height: endY - startY)
       }

--- a/Source/Timeline/TimelineView.swift
+++ b/Source/Timeline/TimelineView.swift
@@ -384,7 +384,15 @@ public final class TimelineView: UIView {
       let descriptor = attributes.descriptor
       let eventView = eventViews[idx]
       eventView.frame = attributes.frame
-      eventView.frame = CGRect(x: attributes.frame.minX,
+        
+      var x: CGFloat
+      if UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft {
+          x = 0
+      } else {
+        x = attributes.frame.minX
+      }
+        
+      eventView.frame = CGRect(x: x,
                                y: attributes.frame.minY,
                                width: attributes.frame.width - style.eventGap,
                                height: attributes.frame.height - style.eventGap)


### PR DESCRIPTION
## About this Pull Request and why it's important
As you may know, in apps that their language is written right-to-left, the layout is mirrored to match the text.
In this Pull Request, I added RTL support for the layout, and transitions.
That means that the layout will be mirrored when the language is written right-to-left, as it should have been.

## Preview
### Hebrew (written right-to-left)
<img src="https://user-images.githubusercontent.com/52978143/103100393-fea12600-461a-11eb-95dc-54006c773b56.jpeg" alt="drawing" width="250"/>

### English (written left-to-right)
to show that the layout remains the same in LTR languages
<img src="https://user-images.githubusercontent.com/52978143/103103839-90655f00-462c-11eb-8840-44ae91b7dc18.jpeg" alt="drawing" width="250"/>

**It's important to remember that this will happen automatically in RTL languages. In all the other languages everything will remain the same.**

## What did I add RTL support to
I added RTL support to:

- Day Selector
- Hour Timeline
- Text in Hour Timeline
- UIPageViewController Navigation Direction
- Swipe Label View text changing animation
- Day Symbols View
- Current Time Indicator
- Event View
- Events Layout
- Accented Hour
- All Day View

If I forgot something please comment and I'll add support for it.

## How can the code know if the app language is written RTL
I used the next code to determine that:
```swift
let rtl = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft
```
I found it working even if the app language is different than the device language.
_______
I also suggest that next time you should use constraints instead of points on the screen, it would make everything way easier. Thanks for reviewing! 😃