### PR TITLE
sample: bump CalendarKit version to 1.1.X

### DIFF
--- a/CalendarKitDemo/CalendarApp.xcodeproj/project.pbxproj
+++ b/CalendarKitDemo/CalendarApp.xcodeproj/project.pbxproj
@@ -357,7 +357,7 @@
 			repositoryURL = "https://github.com/richardtop/CalendarKit.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.0.9;
+				minimumVersion = 1.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
The sample was not building anymore when cloning and opening the project due to API change in CalendarKit