### PR TITLE
Fix DayDateCell vertical alignment by sizing dateLabel before positioning

### DIFF
--- a/Sources/Header/DaySelector/DayDateCell.swift
+++ b/Sources/Header/DaySelector/DayDateCell.swift
@@ -93,9 +93,10 @@ public final class DayDateCell: UIView, DaySelectorItemProtocol {
         dayLabel.sizeToFit()
         dayLabel.center.y = center.y
         let interItemSpacing: Double = selected ? 5 : 3
+        dateLabel.frame.size = CGSize(width: 30, height: 30)
         dateLabel.center.y = center.y
         dateLabel.frame.origin.x = dayLabel.frame.maxX + interItemSpacing
-        dateLabel.frame.size = CGSize(width: 30, height: 30)
+        
         
         let freeSpace = bounds.width - (dateLabel.frame.origin.x + dateLabel.frame.width)
         let padding = freeSpace / 2


### PR DESCRIPTION
## Summary
Fixes a vertical misalignment between weekday and day number in `DayDateCell`.

## Affected platform
- Reproduced only on **iPad** running **iOS 26** (regular size class).
- Not reproduced on iPhone / compact layout.

## Root cause
`dateLabel.frame.size` was set after positioning, leading to incorrect final alignment.

## Fix
In `DayDateCell.layoutSubviews`, set `dateLabel.frame.size` before applying position.

## Verification
- Before: weekday and day number are not aligned (see screenshot).
- After: weekday and day number are correctly aligned.

<img width="2048" height="2732" alt="Simulator Screenshot - iPad Air 13-inch (M3) - 2026-03-03 at 15 52 41" src="https://github.com/user-attachments/assets/40d374f3-6406-48f7-8641-5f4acd9df484" />